### PR TITLE
Fixed and updated CryMat Derivation code tables and tests

### DIFF
--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -379,9 +379,10 @@ class Verifier(CryMat):
 
     Attributes:
 
-
     Properties:
 
+    Methods:
+        verify: verifies signature
 
     """
 
@@ -392,12 +393,51 @@ class Verifier(CryMat):
         """
         super(Signer, self).__init__(**kwa)
 
-    def verify(sig, data):
+        if self.code == CryOne.Ed25519N:
+            self._verify = self._ed25519
+        else:
+            self_verify = self._unknown
+
+
+    def verify(sig, ser):
         """
-        Returns True if sig verifies on data given .raw as verifier public key
-        for ._verify determined by .code
+        Returns True if bytes signature sig verifies on bytes serializtion ser
+        using .raw as verifier public key for ._verify cipher suite determined
+        by .code
         """
-        pass
+        return (self._verify(sig=sig, ser=ser, key=self.raw))
+
+    @staticmethod
+    def _unknown(sig, ser, key):
+        """
+        Returns False
+        Unknown verificaton cipher suite
+
+        Parameters:
+            key is bytes public key
+            sig is bytes signature
+            ser is bytes serialization
+        """
+        return False
+
+    @staticmethod
+    def _ed25519(sig, ser, key):
+        """
+        Returns True if verified False otherwise
+        Verifiy ed25519 sig on ser using key
+
+        Parameters:
+            key is bytes public key
+            sig is bytes signature
+            ser is bytes serialization
+        """
+        try:  # verify returns None if valid else raises ValueError
+            result = pysodium.crypto_sign_verify_detached(sig, ser, key)
+        except Exception as ex:
+            return False
+
+        return True
+
 
 
 BASE64_PAD = '='

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -105,16 +105,18 @@ class CryOneCodex:
 
     Note binary length of everything in CryOneCodex results in 1 Base64 pad byte.
     """
-    Ed25519N:     str = 'A'  #  Ed25519 verification key non-transferable, basic derivation.
-    X25519:       str = 'B'  #  X25519 public encryption key, converted from Ed25519.
-    Ed25519:      str = 'C'  #  Ed25519 verification key basic derivation
-    Blake3_256:   str = 'D'  #  Blake3 256 bit digest self-addressing derivation.
-    Blake2b_256:  str = 'E'  #  Blake2b 256 bit digest self-addressing derivation.
-    Blake2s_256:  str = 'F'  #  Blake2s 256 bit digest self-addressing derivation.
-    ECDSA_256k1N: str = 'G'  #  ECDSA secp256k1 verification key non-transferable, basic derivation.
-    ECDSA_256k1:  str = 'H'  #  Ed25519 verification key basic derivation
-    SHA3_256:     str = 'I'  #  SHA3 256 bit digest self-addressing derivation.
-    SHA2_256:     str = 'J'  #  SHA2 256 bit digest self-addressing derivation.
+    Seed_256:     str = 'A'  #  256 Bit Random Seed or private key
+    Ed25519N:     str = 'B'  #  Ed25519 verification key non-transferable, basic derivation.
+    X25519:       str = 'C'  #  X25519 public encryption key, converted from Ed25519.
+    Ed25519:      str = 'D'  #  Ed25519 verification key basic derivation
+    Blake3_256:   str = 'E'  #  Blake3 256 bit digest self-addressing derivation.
+    Blake2b_256:  str = 'F'  #  Blake2b 256 bit digest self-addressing derivation.
+    Blake2s_256:  str = 'G'  #  Blake2s 256 bit digest self-addressing derivation.
+    SHA3_256:     str = 'H'  #  SHA3 256 bit digest self-addressing derivation.
+    SHA2_256:     str = 'I'  #  SHA2 256 bit digest self-addressing derivation.
+    Seed_448:     str = 'J'  #  448 Bit Random Seed or private key
+    X448:         str = 'K'  #  X448 public encryption key, converted from Ed448
+
 
     def __iter__(self):
         return iter(astuple(self))
@@ -124,13 +126,13 @@ CryOne = CryOneCodex()  # Make instance
 # Mapping of Code to Size
 CryOneSizes = {
                "A": 44, "B": 44, "C": 44, "D": 44, "E": 44, "F": 44,
-               "G": 44, "H": 44, "I": 44, "J": 44,
+               "G": 44, "H": 44, "I": 44, "J": 76, "K": 76,
               }
 
 # Mapping of Code to Size
 CryOneRawSizes = {
                "A": 32, "B": 32, "C": 32, "D": 32, "E": 32, "F": 32,
-               "G": 32, "H": 32, "I": 32, "J": 32,
+               "G": 32, "H": 32, "I": 32, "J": 56, "K": 56,
               }
 
 
@@ -143,8 +145,9 @@ class CryTwoCodex:
 
     Note binary length of everything in CryTwoCodex results in 2 Base64 pad bytes.
     """
-    Ed25519:     str =  '0A'  # Ed25519 signature.
-    ECDSA_256k1: str = '0B'  # ECDSA secp256k1 signature.
+    Seed_128:    str = '0A'  # Ed25519 signature.
+    Ed25519:     str = '0B'  # Ed25519 signature.
+    ECDSA_256k1: str = '0C'  # ECDSA secp256k1 signature.
 
 
     def __iter__(self):
@@ -154,14 +157,16 @@ CryTwo = CryTwoCodex()  #  Make instance
 
 # Mapping of Code to Size
 CryTwoSizes = {
-               "0A": 88,
+               "0A": 24,
+               "0B": 88,
                "0B": 88,
               }
 
 CryTwoRawSizes = {
-               "0A": 64,
-               "0B": 64,
-              }
+                  "0A": 16,
+                  "0B": 64,
+                  "0B": 64,
+                 }
 
 @dataclass(frozen=True)
 class CryFourCodex:
@@ -172,6 +177,8 @@ class CryFourCodex:
 
     Note binary length of everything in CryFourCodex results in 0 Base64 pad bytes.
     """
+    ECDSA_256k1N:  str = "1AAA"  # ECDSA secp256k1 verification key non-transferable, basic derivation.
+    ECDSA_256k1:   str = "1AAB"  # Ed25519 verification key basic derivation
 
     def __iter__(self):
         return iter(astuple(self))
@@ -179,9 +186,15 @@ class CryFourCodex:
 CryFour = CryFourCodex()  #  Make instance
 
 # Mapping of Code to Size
-CryFourSizes = {}
+CryFourSizes = {
+                "1AAA": 48,
+                "1AAB": 48,
+               }
 
-CryFourRawSizes = {}
+CryFourRawSizes = {
+                   "1AAA": 33,
+                   "1AAB": 33,
+                  }
 
 # all sizes in one dict
 CrySizes = dict(CryOneSizes)
@@ -391,7 +404,7 @@ class Verifier(CryMat):
         Assign verification cipher suite function to ._verify
 
         """
-        super(Signer, self).__init__(**kwa)
+        super(Verifier, self).__init__(**kwa)
 
         if self.code == CryOne.Ed25519N:
             self._verify = self._ed25519
@@ -399,11 +412,15 @@ class Verifier(CryMat):
             self_verify = self._unknown
 
 
-    def verify(sig, ser):
+    def verify(self, sig, ser):
         """
-        Returns True if bytes signature sig verifies on bytes serializtion ser
+        Returns True if bytes signature sig verifies on bytes serialization ser
         using .raw as verifier public key for ._verify cipher suite determined
         by .code
+
+        Parameters:
+            sig is bytes signature
+            ser is bytes serialization
         """
         return (self._verify(sig=sig, ser=ser, key=self.raw))
 

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -750,7 +750,7 @@ def test_event_manual():
 
     """
     result = pysodium.crypto_sign_verify_detached(sig0raw, txsrdr.raw, aidmat.raw)
-    assert not result
+    assert not result  # None if verify else raises ValueError
 
     txsigmat = SigMat(raw=sig0raw, code=SigTwo.Ed25519, index=0)
     assert txsigmat.qb64 == 'AAbtzfaUNKhDf84JFhLiw_JOaj8v1KhmZsd4aQYKJ4KyrpB2X_8cs31MGqJgMHj5-JY5l3OXLvphaHLvGzIs2PBg'

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -15,7 +15,7 @@ from base64 import urlsafe_b64encode as encodeB64
 from base64 import urlsafe_b64decode as decodeB64
 
 from keri.kering import Version, Versionage, ValidationError
-from keri.core.coring import CrySelect, CryOne, CryTwo, CryFour, CryMat
+from keri.core.coring import CrySelect, CryOne, CryTwo, CryFour, CryMat, Verifier
 from keri.core.coring import CryOneSizes, CryOneRawSizes, CryTwoSizes, CryTwoRawSizes
 from keri.core.coring import CryFourSizes, CryFourRawSizes, CrySizes, CryRawSizes
 from keri.core.coring import SigSelect, SigTwo, SigTwoSizes, SigTwoRawSizes
@@ -39,26 +39,28 @@ def test_cryderivationcodes():
     for x in ['0']:
         assert x in CrySelect
 
-    assert CryOne.Ed25519N == 'A'
-    assert CryOne.X25519 == 'B'
-    assert CryOne.Ed25519 == 'C'
-    assert CryOne.Blake3_256 == 'D'
-    assert CryOne.Blake2b_256 == 'E'
-    assert CryOne.Blake2s_256 == 'F'
-    assert CryOne.ECDSA_256k1N == 'G'
-    assert CryOne.ECDSA_256k1 == 'H'
-    assert CryOne.SHA3_256 == 'I'
-    assert CryOne.SHA2_256 == 'J'
+    assert CryOne.Seed_256 == 'A'
+    assert CryOne.Ed25519N == 'B'
+    assert CryOne.X25519 == 'C'
+    assert CryOne.Ed25519 == 'D'
+    assert CryOne.Blake3_256 == 'E'
+    assert CryOne.Blake2b_256 == 'F'
+    assert CryOne.Blake2s_256 == 'G'
+    assert CryOne.SHA3_256 == 'H'
+    assert CryOne.SHA2_256 == 'I'
+    assert CryOne.Seed_448 == 'J'
+    assert CryOne.X448 == 'K'
 
     assert '0' not in CryOne
 
-    for x in ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J']:
+    for x in ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K']:
         assert x in CryOne
         assert x in CryOneSizes
         assert x in CryOneRawSizes
 
-    assert CryTwo.Ed25519 == '0A'
-    assert CryTwo.ECDSA_256k1 == '0B'
+    assert CryTwo.Seed_128 == '0A'
+    assert CryTwo.Ed25519 == '0B'
+    assert CryTwo.ECDSA_256k1 == '0C'
 
     assert 'A' not in CryTwo
 
@@ -67,17 +69,21 @@ def test_cryderivationcodes():
         assert x in CryTwoSizes
         assert x in CryTwoRawSizes
 
+    assert CryFour.ECDSA_256k1N == '1AAA'
+    assert CryFour.ECDSA_256k1 == '1AAB'
+
     assert '0' not in CryFour
     assert 'A' not in CryFour
     assert '0A' not in CryFour
 
-    for x in []:
+    for x in ['1AAA', '1AAB']:
         assert x in CryFour
         assert x in CryFourSizes
         assert x in CryFourRawSizes
 
 
-    for x in ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', '0A', '0B']:
+    for x in ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', '0A', '0B',
+              '1AAA', '1AAB']:
         assert x in CrySizes
         assert x in CryRawSizes
 
@@ -143,9 +149,9 @@ def test_crymat():
     """
     # verkey,  sigkey = pysodium.crypto_sign_keypair()
     verkey = b'iN\x89Gi\xe6\xc3&~\x8bG|%\x90(L\xd6G\xddB\xef`\x07\xd2T\xfc\xe1\xcd.\x9b\xe4#'
-    prefix = 'AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM'
-    prebin = (b'\x01\xa5:%\x1d\xa7\x9b\x0c\x99\xfa-\x1d\xf0\x96@'
-              b'\xa13Y\x1fu\x0b\xbd\x80\x1fIS\xf3\x874\xbao\x90\x8c')
+    prefix = 'BaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM'
+    prebin = (b'\x05\xa5:%\x1d\xa7\x9b\x0c\x99\xfa-\x1d\xf0\x96@\xa13Y\x1fu\x0b\xbd\x80\x1f'
+              b'IS\xf3\x874\xbao\x90\x8c')
 
     with pytest.raises(ValueError):
         crymat = CryMat()
@@ -203,8 +209,8 @@ def test_crymat():
     sig64 = encodeB64(sig).decode("utf-8")
     assert sig64 == 'mdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ=='
 
-    qsig64 = '0AmdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ'
-    qbin = (b'\xd0\t\x9d#\xc3\x92BC\t\xf6\xbf\xb1\x8a\x08\xc4\x07!#"\xe6\xbb,q\xf7'
+    qsig64 = '0BmdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ'
+    qbin = (b'\xd0\x19\x9d#\xc3\x92BC\t\xf6\xbf\xb1\x8a\x08\xc4\x07!#"\xe6\xbb,q\xf7'
             b'\x00\xe2v\xd8\xf4\n\xaaX\xcc\x86\xe8\\\x82\x1fg\x19\x17\n\x9e\xcc'
             b'\xf9*\xf2\x9d\xec\xaf\xc7\xf7\xedv\xf7\xc1x!\xddC\xc6\xf2(\x12`\x90')
 
@@ -222,11 +228,8 @@ def test_crymat():
     assert crymat.raw == sig
     assert crymat.code == CryTwo.Ed25519
 
+    """ Done Test """
 
-
-    """
-    Done Test
-    """
 
 def test_sigmat():
     """
@@ -318,9 +321,7 @@ def test_sigmat():
     assert sigmat.index == 5
 
 
-    """
-    Done Test
-    """
+    """ Done Test """
 
 
 def test_serials():
@@ -549,7 +550,7 @@ def test_serder():
     assert len(evt1.digmat.raw) == 32
     assert len(evt1.dig) == 44
     assert len(evt1.dig) == CryOneSizes[CryOne.Blake3_256]
-    assert evt1.dig == 'DB_Qy67YQkcSWmCcZo_3RaoTUQwWGoggAwHlG_0rpmQo'
+    assert evt1.dig == 'EB_Qy67YQkcSWmCcZo_3RaoTUQwWGoggAwHlG_0rpmQo'
 
     evt1 = Serder(ked=ked1)
     assert evt1.kind == kind1
@@ -651,6 +652,32 @@ def test_ilks():
     assert 'drt' in Ilks
 
 
+def test_verifier():
+    """
+    Test the support functionality for verifier subclass of crymat
+    """
+    seed = pysodium.randombytes(pysodium.crypto_sign_SEEDBYTES)
+    verkey, sigkey = pysodium.crypto_sign_seed_keypair(seed)
+
+    with pytest.raises(ValueError):
+        verfer = Verifier()
+
+    verfer = Verifier(raw=verkey, code=CryOne.Ed25519N)
+    assert verfer.raw == verkey
+    assert verfer.code == CryOne.Ed25519N
+
+    #create something to serialize
+    ser = b'abcdefghijklmnopqrstuvwxyz0123456789'
+
+    sig = pysodium.crypto_sign_detached(ser, seed + verkey)  # sigkey = seed + verkey
+
+    result = verfer.verify(sig, ser)
+    assert result == True
+
+
+    """ Done Test """
+
+
 def test_event_manual():
     """
     Test manual process of key event message
@@ -673,7 +700,7 @@ def test_event_manual():
 
     # create qualified aid in basic format
     aidmat = CryMat(raw=verkey, code=CryOne.Ed25519)
-    assert aidmat.qb64 == 'Cr5awcPswp9CkGMncHYbCOpj3P3Qb3i7MyzuKsKJP50s'
+    assert aidmat.qb64 == 'Dr5awcPswp9CkGMncHYbCOpj3P3Qb3i7MyzuKsKJP50s'
 
     # create qualified next public key in basic format
     nxtseed = pysodium.randombytes(pysodium.crypto_sign_SEEDBYTES)
@@ -689,7 +716,7 @@ def test_event_manual():
 
     # create qualified nxt key in basic format
     nxtkeymat = CryMat(raw=verkey, code=CryOne.Ed25519)
-    assert nxtkeymat.qb64 == 'C9URPQjo8zRYYm4NMpQyYWJBDGrMwT6UP4zlspt9YGDU'
+    assert nxtkeymat.qb64 == 'D9URPQjo8zRYYm4NMpQyYWJBDGrMwT6UP4zlspt9YGDU'
 
     # create next hash
     nxtsith =  "{:x}".format(1)  # lowecase hex no leading zeros
@@ -698,12 +725,12 @@ def test_event_manual():
     nxts.append(nxtsith.encode("utf-8"))
     nxts.append(nxtkeymat.qb64.encode("utf-8"))
     nxtsraw = b''.join(nxts)
-    assert nxtsraw == b'1C9URPQjo8zRYYm4NMpQyYWJBDGrMwT6UP4zlspt9YGDU'
+    assert nxtsraw == b'1D9URPQjo8zRYYm4NMpQyYWJBDGrMwT6UP4zlspt9YGDU'
     nxtdig = blake3.blake3(nxtsraw).digest()
-    assert nxtdig == b'm>m\xa0\t\xe1\xfcO\xb8S\xe7\xfcvu\x82\xac&t6\xa2\x7f~\x8e\xaa\xd4v%\xbf>\xe5\x96\x1f'
+    assert nxtdig == b'\xdeWy\xd3=\xcb`\xce\xe9\x99\x0cF\xdd\xb2C6\x03\xa7F\rS\xd6\xfem\x99\x89\xac`<\xaa\x88\xd2'
 
     nxtdigmat = CryMat(raw=nxtdig, code=CryOne.Blake3_256)
-    assert nxtdigmat.qb64 == 'DbT5toAnh_E-4U-f8dnWCrCZ0NqJ_fo6q1HYlvz7llh8'
+    assert nxtdigmat.qb64 == 'E3ld50z3LYM7pmQxG3bJDNgOnRg1T1v5tmYmsYDyqiNI'
 
     sn =  0
     sith = 1
@@ -725,35 +752,30 @@ def test_event_manual():
 
 
     txsrdr = Serder(ked=ked0, kind=Serials.json)
-    assert txsrdr.raw == (b'{"vs":"KERI10JSON000105_","id":"Cr5awcPswp9CkGMncHYbCOpj3P3Qb3i7MyzuKsKJP50s'
-                          b'","sn":"0","ilk":"icp","sith":"1","keys":["Cr5awcPswp9CkGMncHYbCOpj3P3Qb3i7M'
-                          b'yzuKsKJP50s"],"next":"DbT5toAnh_E-4U-f8dnWCrCZ0NqJ_fo6q1HYlvz7llh8","toad":"'
+    assert txsrdr.raw == (b'{"vs":"KERI10JSON000105_","id":"Dr5awcPswp9CkGMncHYbCOpj3P3Qb3i7MyzuKsKJP50s'
+                          b'","sn":"0","ilk":"icp","sith":"1","keys":["Dr5awcPswp9CkGMncHYbCOpj3P3Qb3i7M'
+                          b'yzuKsKJP50s"],"next":"E3ld50z3LYM7pmQxG3bJDNgOnRg1T1v5tmYmsYDyqiNI","toad":"'
                           b'0","wits":[],"data":[],"sigs":[]}')
 
     assert txsrdr.size == 261
 
     txdig = blake3.blake3(txsrdr.raw).digest()
-    assert txdig == b'I\x94\x11_\xb8n\xeai\xc2\xc4\x0ex\xcc\x87\xf4\x86\xf59=\x95\x80(4\x1bV\x87\xbc;o5\x8b4'
+    assert txdig == (b'X\xcb\x8cZd\x1aM\xa9r\xea\x02>u\x1a\xf6\xcc\xfcNqs\x98+\xb5\x80\xf1lD\xe4'
+                     b'?\x02?\xc8')
 
     txdigmat = CryMat(raw=txdig, code=CryOne.Blake3_256)
-    assert txdigmat.qb64 == 'DSZQRX7hu6mnCxA54zIf0hvU5PZWAKDQbVoe8O281izQ'
+    assert txdigmat.qb64 == 'EWMuMWmQaTaly6gI-dRr2zPxOcXOYK7WA8WxE5D8CP8g'
 
     assert txsrdr.dig == txdigmat.qb64
 
     sig0raw = pysodium.crypto_sign_detached(txsrdr.raw, aidseed + aidmat.raw)  #  sigkey = seed + verkey
     assert len(sig0raw) == 64
 
-    """
-    sig0raw = (b'Hu\xc5|V\xd8\x81\xe7(\xf9\xc4\xe5\xc9\xbe\xab\xeb\x17\xa45X\xaf\xd8FN'
-               b'y\xe7\xee\\\x9c\xb4\x8a\xc3\xc4G\x8f\t\x91D\xd1\x80\xe0.\x01QR\xdc\x0e\xcd'
-               b'\xba "\x16\x9b\xf2\xe5(\xa6\xfa\xbb\xf4(\x02\x95\n')
-
-    """
     result = pysodium.crypto_sign_verify_detached(sig0raw, txsrdr.raw, aidmat.raw)
     assert not result  # None if verify else raises ValueError
 
     txsigmat = SigMat(raw=sig0raw, code=SigTwo.Ed25519, index=0)
-    assert txsigmat.qb64 == 'AAbtzfaUNKhDf84JFhLiw_JOaj8v1KhmZsd4aQYKJ4KyrpB2X_8cs31MGqJgMHj5-JY5l3OXLvphaHLvGzIs2PBg'
+    assert txsigmat.qb64 == 'AARbCWt5fr07OOxJgXVjnA0Em-nIx3nVRxIRAXVXO-Arwuy0MKkzG-yTbSczwPKR-nsbgTCwo964pxLWqVK6jxCw'
     assert len(txsigmat.qb64) == 88
 
     msgb = txsrdr.raw + txsigmat.qb64.encode("utf-8")
@@ -768,4 +790,4 @@ def test_event_manual():
     """
 
 if __name__ == "__main__":
-    test_event_manual()
+    test_verifier()

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -630,7 +630,7 @@ def test_serder():
     Done Test
     """
 
-def test_ilds():
+def test_ilks():
     """
     Test Ilkage namedtuple instance Ilks
     """


### PR DESCRIPTION
Oversight forgot to include random seed codes.  Decided to group by family so had to move other codes down. Hopefully no do this often.  Also ends secp256k1 pub keys are 33 bytes not 32 bytes to moved to correct table.