### PR TITLE
Preliminatry support for processing KERI events

### DIFF
--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -1631,11 +1631,8 @@ class Kevery:
         if aid not in KELs:  #  first seen event for aid
             if ilk == Ilks.icp:  # first seen and inception so verify event keys
                 # kever init verifies basic inception stuff and signatures
-                # raises exception if problem
+                # raises exception if problem adds to KEL Kevers
                 kever = Kever(serder=serder, sigs=sigs)  # create kever from serder
-
-                KELS[aid][dig] = Kevage(serder=serder, sigs=sigs)
-                Kevers[aid][dig] = kever
 
             else:  # not inception so can't verify add to escrow
                 # log escrowed
@@ -1682,7 +1679,7 @@ class Kevery:
                                                                       kever.dig))
 
                     # verify signatures etc and update state if valid
-                    # raise exception if problem
+                    # raise exception if problem. adds to KELs
                     kever.update(serder=serder, sigs=sigs)
 
 
@@ -1777,6 +1774,8 @@ class Kever:
             if "trait" in d and d["trait"] == "establishOnly":
                 self.establishOnly = True
 
+        KELS[aid][dig] = Kevage(serder=serder, sigs=sigs)
+        Kevers[aid][dig] = kever
 
 
 
@@ -1865,16 +1864,19 @@ class Kever:
             self.wits = ked["wits"]
             self.data = ked["data"]
 
-            # update Kever and add to KELs
-            # Kever.update(verifiers, sn, dig)
+
             KELS[aid][dig] = Kevage(serder=serder, sigs=sigs)
 
 
         elif ilk == Ilks.ixn:  # subsequent interaction event
+            if self.establishOnly:
+                raise ValidationError("Unexpected non-establishment event = {}."
+                                  "".format(serder))
             if not self.verify(serder=serder, sigs=sigs):
                 raise ValidationError("Failure verifying signatures = {} for {}"
                                   "".format(sigs, serder))
 
+            # update state
             self.sn = sn
             self.dig = dig
             KELS[aid][dig] = Kevage(serder=serder, sigs=sigs)

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -467,9 +467,15 @@ class Signer(CryMat):
 
     """
 
-    def __init__(self,raw=b'', code=CryOne.Ed25519_Seed, **kwa):
+    def __init__(self,raw=b'', code=CryOne.Ed25519_Seed, transferable=True, **kwa):
         """
         Assign signing cipher suite function to ._sign
+
+        Parameters:  See CryMat for inherted parameters
+            raw is bytes crypto material seed or private key
+            code is derivation code
+            transferable is Boolean True means verifier code is transferable
+                                    False othersize non-transerable
 
         """
         try:
@@ -484,7 +490,9 @@ class Signer(CryMat):
         if self.code == CryOne.Ed25519_Seed:
             self._sign = self._ed25519
             verkey, sigkey = pysodium.crypto_sign_seed_keypair(self.raw)
-            verifier = Verifier(raw=verkey, code=CryOne.Ed25519)
+            verifier = Verifier(raw=verkey,
+                                code=CryOne.Ed25519 if transferable
+                                                    else CryOne.Ed25519N )
         else:
             raise ValueError("Unsupported signer code = {}.".format(self.code))
 

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -1458,7 +1458,9 @@ class Serder:
         """
         return self.digmat.qb64
 
-Kevers = {}  # dict of existing Kevers indexed by .aid.qb64 of each Kever
+Kevers = dict()  # dict of existing Kevers indexed by aid.qb64 of each Kever
+KELs = dict()  # dict of Key Event Logs = lists indexed by aid.qb64 of each Kever
+DELs = dict(aids=dict()) # dict of dict of dup events by aid.qb64 then by event dig
 
 class Kevery:
     """
@@ -1467,12 +1469,9 @@ class Kevery:
 
     Has the following public attributes and properties:
 
-     Attributes:
-
+    Attributes:
 
     Properties:
-
-
 
     """
     def __init__(self, kes=bytearray(), ked=None, sigs=None):

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -412,7 +412,6 @@ class Verifier(CryMat):
         verify: verifies signature
 
     """
-
     def __init__(self, **kwa):
         """
         Assign verification cipher suite function to ._verify
@@ -478,7 +477,6 @@ class Signer(CryMat):
         sign: create signature
 
     """
-
     def __init__(self,raw=b'', code=CryOne.Ed25519_Seed, transferable=True, **kwa):
         """
         Assign signing cipher suite function to ._sign
@@ -571,7 +569,6 @@ class Digester(CryMat):
         verify: verifies signature
 
     """
-
     def __init__(self, raw=b'', ser=b'', code=CryOne.Blake3_256, **kwa):
         """
         Assign digest verification function to ._verify
@@ -638,7 +635,6 @@ class Nexter(Digester):
 
 
     """
-
     def __init__(self, ser=b'', sith=None, keys=None, ked=None, **kwa):
         """
         Assign digest verification function to ._verify
@@ -724,7 +720,6 @@ class Aider(CryMat):
         verify():  Verifies derivation of aid
 
     """
-
     def __init__(self, raw=b'', code=CryOne.Ed25519N, ked=None, **kwa):
         """
         assign ._verify to verify derivation of aid  = .qb64
@@ -940,7 +935,6 @@ class SigFourCodex:
     """
     Ed448: str =  '0A'  # Ed448 signature.
 
-
     def __iter__(self):
         return iter(astuple(self))
 
@@ -971,7 +965,6 @@ class SigFiveCodex:
     Next two code charaters select index into current signing key list
     Only provide first three characters here
     """
-
     def __iter__(self):
         return iter(astuple(self))
 
@@ -1010,7 +1003,6 @@ class SigMat:
         .qb64 str in Base64 with derivation code and signature crypto material
         .qb2  bytes in binary with derivation code and signature crypto material
     """
-
     def __init__(self, raw=b'', qb64='', qb2='', code=SigTwo.Ed25519, index=0):
         """
         Validate as fully qualified

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -654,7 +654,7 @@ class Aider(CryMat):
             raise ValueError("Unsupported code = {} for airder.".format(self.code))
 
 
-    def verify(self, iked):
+    def verify(self, ked):
         """
         Returns True if derivation from iked for .code matches .qb64,
                 False otherwise
@@ -662,11 +662,11 @@ class Aider(CryMat):
         Parameters:
             iked is inception key event dict
         """
-        return (self._verify(iked=iked, aid=self.qb64))
+        return (self._verify(ked=ked, aid=self.qb64))
 
 
     @staticmethod
-    def _ed25519n(iked, aid):
+    def _ed25519n(ked, aid):
         """
         Returns True if verified raises exception otherwise
         Verify derivation of fully qualified Base64 aid from inception iked dict
@@ -676,14 +676,14 @@ class Aider(CryMat):
             aid is Base64 fully qualified
         """
         try:
-            keys = iked["keys"]
+            keys = ked["keys"]
             if len(keys) < 1:
                 return False
 
             if keys[0] != aid:
                 return False
 
-            if iked["next"]:  # must be empty
+            if ked["next"]:  # must be empty
                 return False
 
         except Exception as ex:
@@ -693,7 +693,7 @@ class Aider(CryMat):
 
 
     @staticmethod
-    def _ed25519(iked, aid):
+    def _ed25519(ked, aid):
         """
         Returns True if verified raises exception otherwise
         Verify derivation of fully qualified Base64 aid from inception data dict
@@ -703,7 +703,7 @@ class Aider(CryMat):
             aid is Base64 fully qualified
         """
         try:
-            keys = iked["keys"]
+            keys = ked["keys"]
             if len(keys) < 1:
                 return False
 

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -260,7 +260,7 @@ class CryMat:
                                                              CryRawSizes[code]))
 
             self._code = code
-            self._raw = raw
+            self._raw = bytes(raw)  # crypto ops require bytes not bytearray
 
         elif qb64:
             if hasattr(qb64, "decode"):  # converts bytes like to str
@@ -929,7 +929,7 @@ class SigMat:
 
             self._code = code  # front part without index
             self._index = index
-            self._raw = raw
+            self._raw = bytes(raw)  # crypto ops require bytes not bytearray
 
         elif qb64:
             if hasattr(qb64, "decode"):  # converts bytes like to str
@@ -1279,7 +1279,7 @@ class Serder:
     def raw(self, raw):
         """ raw property setter """
         ked, kind, size = self._inhale(raw=raw)
-        self._raw = raw[:size]
+        self._raw = bytes(raw[:size])  # crypto ops require bytes not bytearray
         self._ked = ked
         self._kind = kind
         self._size = size

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -1550,8 +1550,8 @@ class Kevery:
         ked = serder.ked
         keys = ked["keys"]
         sigs = []  # list of SigMat instances for attached signatures
-        if "sigs" in ked and ked["sigs"]: # extract signatures given indexes
-            indexes = ked["sigs"]
+        if "idxs" in ked and ked["idxs"]: # extract signatures given indexes
+            indexes = ked["idxs"]
             if isinstance(indexes, str):
                 nsigs = int(indexes, 16)
                 if nsigs < 1:
@@ -1589,7 +1589,7 @@ class Kevery:
                                                                         index))
 
             else:
-                raise ValidationError("Invalid format of sigs indexes = {}."
+                raise ValidationError("Invalid format of indexes = {}."
                                           "".format(indexes))
 
         else:  # no info on attached sigs

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -1451,10 +1451,9 @@ class Serder:
 
 
 
-
-class Corver:
+class Kever:
     """
-    Corver is KERI key event verifier class
+    Kever is KERI key event verifier class
     Only supports current version VERSION
 
     Has the following public attributes and properties:
@@ -1463,30 +1462,54 @@ class Corver:
         .serder is Serder instance created from serialized event
 
     """
-    def __init__(self, raws=bytearray()):
+    def __init__(self, kes=bytearray(), ked=None, sigs=None):
         """
-        Extract event and attached signatures from event stream raws
+        Extract and verify event and attached signatures from key event stream kes
 
         Parameters:
-          raws is bytes of serialized event stream.
-            Stream raws may have zero or more sets of a serialized event plus any
-            attached signatures
+            kes is bytearray of serialized event stream. May contain multiple sets
+                of serialized events with attached signatures.
+            ked is key event dict extracted from serialized event
+            sigs is list of qualified qb64 signatures
+
 
 
         Attributes:
-
+            .version is version of current event
+            .aid is fully qualified qb64 autonomic id
+            .sn is sequence number
+            .predig is qualified qb64 digest of previous event
+            .dig is qualified qb64 dige of current event
+            .ilk is str of current event type
+            .sith is int or list of current signing threshold
+            .keys is list of qb64 current verification keys
+            .nxt is qualified qb64 of next sith plus next signing keys
+            .toad is int threshold of accountable duplicity
+            .wits is list of qualified qb64 aids for witnesses
+            .data is list of configuration data mappings
+            .indices is int or list of signature indices of current event if any
 
         Properties:
-          .raw is bytes of serialized event plus attached signatures
-          .size is int of number of bytes in serialed event plus attached signatures
-
 
 
         Note:
           loads and jumps of json use str whereas cbor and msgpack use bytes
         """
-        if not raws:
-            raise ValueError("Empty serialized event stream.")
+        # initial state is vacuous
+        self.version = None
+        self.aid = None
+        self.sn =  None
+        self.predig = None
+        self.dig = None
+        self.ilk = None
+        self.sith = None
+        self.keys = []
+        self.nxt = None
+        self.toad = None
+        self.wits = None
+        self.data = None
+        self.indices = None
 
-        if not isinstance(raws, bytearray):
-            raws = bytearray(raws)
+
+        if not isinstance(kes, bytearray):
+            kes = bytearray(raws)

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -16,7 +16,7 @@ import msgpack
 import pysodium
 import blake3
 
-from ..kering import ValidationError, EmptyMaterialError, VersionError
+from ..kering import ValidationError, VersionError, EmptyMaterialError, DerivationError
 from ..kering import Versionage, Version
 
 Serialage = namedtuple("Serialage", 'json mgpk cbor')
@@ -639,7 +639,7 @@ class Aider(CryMat):
 
     """
 
-    def __init__(self, raw=b'', code=CryOne.Ed25519N, **kwa):
+    def __init__(self, raw=b'', code=CryOne.Ed25519N, ked=None, **kwa):
         """
         assign ._verify to verify derivation of aid  = .qb64
 
@@ -652,6 +652,13 @@ class Aider(CryMat):
             self._verify = self._ed25519
         else:
             raise ValueError("Unsupported code = {} for airder.".format(self.code))
+
+    @staticmethod
+    def _derive(ked):
+        """
+        Returns Verifier derived from ked (key event dict)
+        """
+
 
 
     def verify(self, ked):

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -1458,8 +1458,24 @@ class Kever:
 
     Has the following public attributes and properties:
 
-    Attributes:
-        .serder is Serder instance created from serialized event
+     Attributes:
+        .version is version of current event
+        .aid is fully qualified qb64 autonomic id
+        .sn is sequence number
+        .predig is qualified qb64 digest of previous event
+        .dig is qualified qb64 dige of current event
+        .ilk is str of current event type
+        .sith is int or list of current signing threshold
+        .keys is list of qb64 current verification keys
+        .nxt is qualified qb64 of next sith plus next signing keys
+        .toad is int threshold of accountable duplicity
+        .wits is list of qualified qb64 aids for witnesses
+        .data is list of configuration data mappings
+        .indices is int or list of signature indices of current event if any
+
+    Properties:
+
+
 
     """
     def __init__(self, kes=bytearray(), ked=None, sigs=None):
@@ -1472,28 +1488,6 @@ class Kever:
             ked is key event dict extracted from serialized event
             sigs is list of qualified qb64 signatures
 
-
-
-        Attributes:
-            .version is version of current event
-            .aid is fully qualified qb64 autonomic id
-            .sn is sequence number
-            .predig is qualified qb64 digest of previous event
-            .dig is qualified qb64 dige of current event
-            .ilk is str of current event type
-            .sith is int or list of current signing threshold
-            .keys is list of qb64 current verification keys
-            .nxt is qualified qb64 of next sith plus next signing keys
-            .toad is int threshold of accountable duplicity
-            .wits is list of qualified qb64 aids for witnesses
-            .data is list of configuration data mappings
-            .indices is int or list of signature indices of current event if any
-
-        Properties:
-
-
-        Note:
-          loads and jumps of json use str whereas cbor and msgpack use bytes
         """
         # initial state is vacuous
         self.version = None
@@ -1513,3 +1507,56 @@ class Kever:
 
         if not isinstance(kes, bytearray):
             kes = bytearray(raws)
+
+
+class Keger:
+    """
+    Keger is KERI key event generator class
+    Only supports current version VERSION
+
+    Has the following public attributes and properties:
+
+    Attributes:
+        .version is version of current event
+        .aid is fully qualified qb64 autonomic id
+        .sn is sequence number
+        .predig is qualified qb64 digest of previous event
+        .dig is qualified qb64 dige of current event
+        .ilk is str of current event type
+        .sith is int or list of current signing threshold
+        .keys is list of qb64 current verification keys
+        .nxt is qualified qb64 of next sith plus next signing keys
+        .toad is int threshold of accountable duplicity
+        .wits is list of qualified qb64 aids for witnesses
+        .data is list of configuration data mappings
+        .indices is int or list of signature indices of current event if any
+
+    Properties:
+
+
+
+    """
+    def __init__(self):
+        """
+        Extract and verify event and attached signatures from key event stream kes
+
+        Parameters:
+
+
+        """
+        # initial state is vacuous
+        self.version = None
+        self.aid = None
+        self.sn =  None
+        self.predig = None
+        self.dig = None
+        self.ilk = None
+        self.sith = None
+        self.keys = []
+        self.nxt = None
+        self.toad = None
+        self.wits = None
+        self.data = None
+        self.indices = None
+
+

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -263,6 +263,8 @@ class CryMat:
             self._raw = raw
 
         elif qb64:
+            if hasattr(qb64, "decode"):  # converts bytes like to str
+                qb64 = qb64.decode("utf-8")
             self._exfil(qb64)
 
         elif qb2:  # rewrite to use direct binary exfiltration
@@ -371,6 +373,16 @@ class CryMat:
         Assumes self.raw and self.code are correctly populated
         """
         return self._infil()
+
+
+    @property
+    def qb64b(self):
+        """
+        Property qb64b:
+        Returns Fully Qualified Base64 Version encoded as bytes
+        Assumes self.raw and self.code are correctly populated
+        """
+        return self.qb64.encode("utf-8")
 
 
     @property
@@ -920,6 +932,8 @@ class SigMat:
             self._raw = raw
 
         elif qb64:
+            if hasattr(qb64, "decode"):  # converts bytes like to str
+                qb64 = qb64.decode("utf-8")
             self._exfil(qb64)
 
         elif qb2:  # rewrite to use direct binary exfiltration
@@ -1053,6 +1067,16 @@ class SigMat:
         Assumes self.raw and self.code are correctly populated
         """
         return self._infil()
+
+
+    @property
+    def qb64b(self):
+        """
+        Property qb64b:
+        Returns Fully Qualified Base64 Version encoded as bytes
+        Assumes self.raw and self.code are correctly populated
+        """
+        return self.qb64.encode("utf-8")
 
 
     @property

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -1909,7 +1909,7 @@ class Keger:
         .nxt is qualified qb64 of next sith plus next signing keys
         .toad is int threshold of accountable duplicity
         .wits is list of qualified qb64 aids for witnesses
-        .confis list of inception configuration data mappings
+        .conf is list of inception configuration data mappings
         .indexes is int or list of signature indexes of current event if any
 
     Properties:

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -659,7 +659,7 @@ class Aider(CryMat):
         elif self.code == CryOne.Ed25519:
             self._verify = self._ed25519
         else:
-            raise ValueError("Unsupported code = {} for airder.".format(self.code))
+            raise ValueError("Unsupported code = {} for aider.".format(self.code))
 
     @staticmethod
     def _derive(ked):

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -656,9 +656,11 @@ class Aider(CryMat):
     @staticmethod
     def _derive(ked):
         """
-        Returns Verifier derived from ked (key event dict)
+        Returns Verifier derived from ked (key event dict) to use for .raw & .code
         """
-
+        if "keys" not in ked:
+            raise DerivationError("Missing 'keys' field in ked = {}.".format(ked))
+        keys = ked["keys"]
 
 
     def verify(self, ked):
@@ -684,7 +686,7 @@ class Aider(CryMat):
         """
         try:
             keys = ked["keys"]
-            if len(keys) < 1:
+            if len(keys) != 1:
                 return False
 
             if keys[0] != aid:
@@ -711,7 +713,7 @@ class Aider(CryMat):
         """
         try:
             keys = ked["keys"]
-            if len(keys) < 1:
+            if len(keys) != 1:
                 return False
 
             if keys[0] != aid:

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -1703,20 +1703,24 @@ class Kever:
 
     Has the following public attributes and properties:
 
-     Attributes:
+    Class Attributes:
+        .EstablishOnly
+
+    Attributes:
+        .serder is Serder instance of current packet
+        .sigs is list of SigMat instances of signatures
+        .verifiers is list of Verifier instances of current signing keys
         .version is version of current event
         .aid is fully qualified qb64 autonomic id
         .sn is sequence number
-        .dig is qualified qb64 digest of previous event
+        .dig is qualified qb64 digest of event not prior event
         .ilk is str of current event type
         .sith is int or list of current signing threshold
-        .nxt is qualified qb64 of next sith plus next signing keys
+        .nxt is qualified qb64 of next sith and next signing keys
         .toad is int threshold of accountable duplicity
         .wits is list of qualified qb64 aids for witnesses
         .data is list of configuration data mappings
-        .indices is int or list of signature indices of current event if any
-        .serder is Serder instance of current packet
-        .verifiers is list of Verifier instances of current signing keys
+        .establishOnly is boolean
 
     Properties:
 
@@ -1738,7 +1742,7 @@ class Kever:
         self.serder = serder
         self.verifiers = serder.verifiers  # converts keys to verifiers
         self.sigs = sigs
-        ked = serder.ked
+        ked = self.serder.ked
         sith = ked["sith"]
         if isinstance(sith, str):
             self.sith =  int(ked.sith, 16)
@@ -1750,7 +1754,7 @@ class Kever:
             raise ValidationError("Failure verifying signatures = {} for {}"
                                   "".format(sigs, serder))
 
-        self.version = serder.version  # version switch?
+        self.version = self.serder.version  # version switch?
 
         self.aider = Aider(qb64=ked["id"])
         if not aider.verify(ked=ked):  # invalid aid
@@ -1762,7 +1766,7 @@ class Kever:
             ValidationError("Invalid sn = {} for inception ked = {}."
                                               "".format(self.sn, ked))
 
-        self.dig = None  # prior digest is None for inception event
+        self.dig = self.serder.dig
 
         self.ilk = ked["ilk"]
         if self.ilk != Ilks.icp:
@@ -1786,8 +1790,16 @@ class Kever:
     def verify(self, sigs=None, serder=None, sith=None, verifiers=None):
         """
         Verify sigs against serder using sith and verifiers
+        Assumes that sigs already extracted correctly wrt indices
         If any of serder, sith, verifiers not provided then replace missing
            value with respective attribute .serder, .sith .verifiers instead
+
+        Parameters:
+            sigs is list of SigMat instances
+            serder is Serder instance
+            sith is int threshold
+            verifiers is list of Verifier instances
+
         """
         sigs = sigs if sigs is not None else self.sigs
         serder = serder if serder is not None else self.serder

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -813,7 +813,8 @@ class Aider(CryMat):
     def _ed25519(ked, aid):
         """
         Returns True if verified raises exception otherwise
-        Verify derivation of fully qualified Base64 aid from inception data dict
+        Verify derivation of fully qualified Base64 aid from
+        inception key event dict (ked)
 
         Parameters:
             iked is inception key event dict
@@ -1712,7 +1713,7 @@ class Kever:
         .nexter is qualified qb64 of next sith and next signing keys
         .toad is int threshold of accountable duplicity
         .wits is list of qualified qb64 aids for witnesses
-        .data is list of configuration data mappings
+        .conf is list of inception configuration data mappings
         .establishOnly is boolean
 
     Properties:
@@ -1766,11 +1767,11 @@ class Kever:
         self.nexter = Nexter(qb64=ked["next"]) if nxt else None  # check for empty
         self.toad = int(ked["toad"], 16)
         self.wits = ked["wits"]
-        self.data = ked["data"]
+        self.conf = ked["conf"]
 
         self.establishOnly = establishOnly if establishOnly is not None else self.EstablishOnly
         self.establishOnly = True if self.establishOnly else False  # ensure boolean
-        for d in self.data:
+        for d in self.conf:
             if "trait" in d and d["trait"] == "establishOnly":
                 self.establishOnly = True
 
@@ -1862,7 +1863,7 @@ class Kever:
             self.nexter = nexter
             self.toad = int(ked["toad"], 16)
             self.wits = ked["wits"]
-            self.data = ked["data"]
+            self.conf = ked["conf"]
 
 
             KELS[aid][dig] = Kevage(serder=serder, sigs=sigs)
@@ -1908,7 +1909,7 @@ class Keger:
         .nxt is qualified qb64 of next sith plus next signing keys
         .toad is int threshold of accountable duplicity
         .wits is list of qualified qb64 aids for witnesses
-        .data is list of configuration data mappings
+        .confis list of inception configuration data mappings
         .indexes is int or list of signature indexes of current event if any
 
     Properties:
@@ -1936,6 +1937,6 @@ class Keger:
         self.nxt = None
         self.toad = None
         self.wits = None
-        self.data = None
+        self.conf = None
         self.indexes = None
 

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -648,12 +648,12 @@ class Nexter(Digester):
 
         """
         try:
-            super(Digester, self).__init__(ser=ser, **kwa)
+            super(Nexter, self).__init__(ser=ser, **kwa)
         except EmptyMaterialError as ex:
             if not (sith and keys) and not ked:
                 raise ex
             ser = self._derive(sith=sith, keys=keys, ked=ked)
-            super(Digester, self).__init__(ser=ser, **kwa)
+            super(Nexter, self).__init__(ser=ser, **kwa)
 
 
     @staticmethod

--- a/src/keri/kering.py
+++ b/src/keri/kering.py
@@ -27,6 +27,14 @@ class ValidationError(KeriError):
         raise ValidationError("error message")
     """
 
+class VersionError(ValidationError):
+    """
+    Bad or Unsupported Version
+
+    Usage:
+        raise VersionError("error message")
+    """
+
 class EmptyMaterialError(ValidationError):
     """
     Empty or Missing Crypto Material
@@ -34,9 +42,10 @@ class EmptyMaterialError(ValidationError):
         raise EmptyMaterialError("error message")
     """
 
-class VersionError(ValidationError):
+class DerivationError(ValidationError):
     """
-    Validation related errors
+    Derivation related errors
     Usage:
-        raise ValidationError("error message")
+        raise DerivationError("error message")
     """
+

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -29,7 +29,8 @@ from keri.core.coring import SigMat
 from keri.core.coring import Serialage, Serials, Mimes, Vstrings
 from keri.core.coring import Versify, Deversify, Rever
 from keri.core.coring import Serder
-from keri.core.coring import Ilkage, Ilks, Kever
+from keri.core.coring import Ilkage, Ilks
+from keri.core.coring import Kever, Kevery, Keger
 
 
 def test_cryderivationcodes():
@@ -936,6 +937,14 @@ def test_kever():
     Key Event Verifier
     """
     kever = Kever()
+    """ Done Test """
+
+def test_kevery():
+    """
+    Test the support functionality for Kevery factory class
+    Key Event Verifier Factory
+    """
+    kevery = Kevery()
     """ Done Test """
 
 def test_keger():

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -368,7 +368,7 @@ def test_serials():
               next = 'DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM',
               toad = 0,
               wits = [],
-              data = [],
+              conf = [],
               idxs = [0]
              )
 
@@ -392,7 +392,7 @@ def test_serials():
     assert icps == (b'{"vs":"KERI10JSON000000_","id":"AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM'
                     b'","sn":"0001","ilk":"icp","dig":"DVPzhzS6b5CMaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAf'
                     b'S","sith":1,"keys":["AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"],"next":"'
-                    b'DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM","toad":0,"wits":[],"data":[],"'
+                    b'DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM","toad":0,"wits":[],"conf":[],"'
                     b'idxs":[0]}')
 
     match = Rever.search(icps)
@@ -416,7 +416,7 @@ def test_serials():
                     b'VPzhzS6b5CM\xa2sn\xa40001\xa3ilk\xa3icp\xa3dig\xd9,DVPzhzS6b5CMaU6JR2nmwyZ'
                     b'-i0d8JZAoTNZH3ULvYAfS\xa4sith\x01\xa4keys\x91\xd9,AaU6JR2nmwyZ-i0d8JZAoTNZH'
                     b'3ULvYAfSVPzhzS6b5CM\xa4next\xd9,DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5'
-                    b'CM\xa4toad\x00\xa4wits\x90\xa4data\x90\xa4idxs\x91\x00')
+                    b'CM\xa4toad\x00\xa4wits\x90\xa4conf\x90\xa4idxs\x91\x00')
 
     match = Rever.search(icps)
     assert match.group() == Vstrings.mgpk.encode("utf-8")
@@ -439,7 +439,7 @@ def test_serials():
     assert icps == (b'\xacbvsqKERI10CBOR000000_bidx,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CMb'
                     b'snd0001cilkcicpcdigx,DVPzhzS6b5CMaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSdsith\x01d'
                     b'keys\x81x,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CMdnextx,DZ-i0d8JZAoTNZ'
-                    b'H3ULvaU6JR2nmwyYAfSVPzhzS6b5CMdtoad\x00dwits\x80ddata\x80didxs\x81\x00')
+                    b'H3ULvaU6JR2nmwyYAfSVPzhzS6b5CMdtoad\x00dwits\x80dconf\x80didxs\x81\x00')
 
     match = Rever.search(icps)
     assert match.group() == Vstrings.cbor.encode("utf-8")
@@ -990,7 +990,7 @@ def test_process_nontransferable():
                 next=nxt,  # hash qual Base64
                 toad="{:x}".format(toad),  # hex string no leading zeros lowercase
                 wits=[],  # list of qual Base64 may be empty
-                data=[],  # list of config ordered mappings may be empty
+                conf=[],  # list of config ordered mappings may be empty
                 idxs="{:x}".format(nsigs)  # single lowercase hex string
                )
 
@@ -1080,7 +1080,7 @@ def test_process_transferable():
                 next=nxt,  # hash qual Base64
                 toad="{:x}".format(toad),  # hex string no leading zeros lowercase
                 wits=[],  # list of qual Base64 may be empty
-                data=[],  # list of config ordered mappings may be empty
+                conf=[],  # list of config ordered mappings may be empty
                 idxs="{:x}".format(nsigs)  # single lowercase hex string
                )
 
@@ -1211,7 +1211,7 @@ def test_process_manual():
                 next=nxtdigmat.qb64,  # hash qual Base64
                 toad="{:x}".format(toad),  # hex string no leading zeros lowercase
                 wits=[],  # list of qual Base64 may be empty
-                data=[],  # list of config ordered mappings may be empty
+                conf=[],  # list of config ordered mappings may be empty
                 idxs=["{:x}".format(index)]  # optional list of lowercase hex strings no leading zeros or single lowercase hex string
                )
 
@@ -1220,13 +1220,13 @@ def test_process_manual():
     assert txsrdr.raw == (b'{"vs":"KERI10JSON000108_","id":"Dr5awcPswp9CkGMncHYbCOpj3P3Qb3i7MyzuKsKJP50s'
                           b'","sn":"0","ilk":"icp","sith":"1","keys":["Dr5awcPswp9CkGMncHYbCOpj3P3Qb3i7M'
                           b'yzuKsKJP50s"],"next":"E3ld50z3LYM7pmQxG3bJDNgOnRg1T1v5tmYmsYDyqiNI","toad":"'
-                          b'0","wits":[],"data":[],"idxs":["0"]}')
+                          b'0","wits":[],"conf":[],"idxs":["0"]}')
 
     assert txsrdr.size == 264
 
     txdig = blake3.blake3(txsrdr.raw).digest()
     txdigmat = CryMat(raw=txdig, code=CryOne.Blake3_256)
-    assert txdigmat.qb64 == 'EzTKQVe4DVmx9rZBPg70sypOoEYf6QROSinSoFfIbrDM'
+    assert txdigmat.qb64 == 'EPYPv3ouNLw45lAI1B40Io4KX935qfxcWdBrtA6-leFc'
 
     assert txsrdr.dig == txdigmat.qb64
 
@@ -1237,7 +1237,7 @@ def test_process_manual():
     assert not result  # None if verifies successfully else raises ValueError
 
     txsigmat = SigMat(raw=sig0raw, code=SigTwo.Ed25519, index=index)
-    assert txsigmat.qb64 == 'AA0eSN02MaVpKer6BEBiBgkK6PmprPinJsZFRr5CAd0XiViWlJrPy1oyitaIibULo2Zx8Ff2KRakHGyu7Ht3nBCg'
+    assert txsigmat.qb64 == 'AAxW5lxJxAmenWwfvgGeDgciKKT-7hP-jOZrHMVCAHgGlnpYX8dfzjppJvbC5s9GQWN4w_1IfTKcwWrU3C9KTYDA'
     assert len(txsigmat.qb64) == 88
     assert txsigmat.index == index
 

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -847,6 +847,9 @@ def test_aider():
     seed = pysodium.randombytes(pysodium.crypto_sign_SEEDBYTES)
     verkey, sigkey = pysodium.crypto_sign_seed_keypair(seed)
 
+    with pytest.raises(ValueError):
+        aider = Aider(raw=verkey, code=CryOne.Blake3_256)
+
     aider = Aider(raw=verkey)  # defaults provide Ed25519N aider
     assert aider.code == CryOne.Ed25519N
     assert len(aider.raw) == CryOneRawSizes[aider.code]

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -1020,7 +1020,7 @@ def test_process_nontransferable():
         assert False
 
     else:
-        ridxs = rser0.ked["sigs"]  # exract signature indices
+        ridxs = rser0.ked["sigs"]  # exract signature indexes
         if isinstance(ridxs, list):
             for idx in ridxs:
                 pass
@@ -1115,7 +1115,7 @@ def test_process_transferable():
         assert False
 
     else:
-        ridxs = rser0.ked["sigs"]  # exract signature indices
+        ridxs = rser0.ked["sigs"]  # exract signature indexes
         if isinstance(ridxs, list):
             for idx in ridxs:
                 pass
@@ -1264,9 +1264,9 @@ def test_process_manual():
     rxvermat = CryMat(qb64=rxverqb64)
     assert rxvermat.qb64 == rxaidmat.qb64  #  basic derivation same
 
-    indices = [ int(index, 16) for index in rxsrdr.ked["sigs"]]
-    assert indices == [0]
-    assert indices[0] == rxsigmat.index
+    indexes = [ int(index, 16) for index in rxsrdr.ked["sigs"]]
+    assert indexes == [0]
+    assert indexes[0] == rxsigmat.index
 
     result = pysodium.crypto_sign_verify_detached(rxsigmat.raw, rxsrdr.raw, rxvermat.raw)
     assert not result  # None if verifies successfully else raises ValueError

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -704,7 +704,7 @@ def test_signer():
     """
     Test the support functionality for signer subclass of crymat
     """
-    signer = Signer()  # defaults provide Ed25519 signer
+    signer = Signer()  # defaults provide Ed25519 signer Ed25519 verifier
     assert signer.code == CryOne.Ed25519_Seed
     assert len(signer.raw) == CryOneRawSizes[signer.code]
     assert signer.verifier.code == CryOne.Ed25519
@@ -729,6 +729,31 @@ def test_signer():
     assert result == False
 
     assert crymat.raw == sigmat.raw
+
+    signer = Signer(transferable=False)  # Ed25519N verifier
+    assert signer.code == CryOne.Ed25519_Seed
+    assert len(signer.raw) == CryOneRawSizes[signer.code]
+    assert signer.verifier.code == CryOne.Ed25519N
+    assert len(signer.verifier.raw) == CryOneRawSizes[signer.verifier.code]
+
+    #create something to sign and verify
+    ser = b'abcdefghijklmnopqrstuvwxyz0123456789'
+
+    crymat = signer.sign(ser)
+    assert crymat.code == CryTwo.Ed25519
+    assert len(crymat.raw) == CryTwoRawSizes[crymat.code]
+    result = signer.verifier.verify(crymat.raw, ser)
+    assert result == True
+
+    sigmat = signer.sign(ser, index=0)
+    assert sigmat.code == SigTwo.Ed25519
+    assert len(sigmat.raw) == SigTwoRawSizes[sigmat.code]
+    assert sigmat.index == 0
+    result = signer.verifier.verify(sigmat.raw, ser)
+    assert result == True
+    result = signer.verifier.verify(sigmat.raw, ser + b'ABCDEFG')
+    assert result == False
+
 
     seed = pysodium.randombytes(pysodium.crypto_sign_SEEDBYTES)
     signer = Signer(raw=seed, code=CryOne.Ed25519_Seed)
@@ -840,8 +865,9 @@ def test_process():
     """
     Test process of generating and validating key event messages
     """
-    signer = Signer()
-    assert signer.code == CryOne.Ed25519_Seed
+    skip0 = Signer(transferable=False)  #  original signing keypair non transferable
+    assert skip0.code == CryOne.Ed25519_Seed
+    assert skip0.verifier.code == CryOne.Ed25519N
 
 
     """ Done Test """
@@ -979,4 +1005,4 @@ def test_process_manual():
     """ Done Test """
 
 if __name__ == "__main__":
-    test_aider()
+    test_process()

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -369,7 +369,7 @@ def test_serials():
               toad = 0,
               wits = [],
               data = [],
-              sigs = [0]
+              idxs = [0]
              )
 
     rot = dict(vs = Vstrings.json,
@@ -384,7 +384,7 @@ def test_serials():
               cuts = [],
               adds = [],
               data = [],
-              sigs = [0]
+              idxs = [0]
              )
 
     icps = json.dumps(icp, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
@@ -393,7 +393,7 @@ def test_serials():
                     b'","sn":"0001","ilk":"icp","dig":"DVPzhzS6b5CMaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAf'
                     b'S","sith":1,"keys":["AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"],"next":"'
                     b'DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM","toad":0,"wits":[],"data":[],"'
-                    b'sigs":[0]}')
+                    b'idxs":[0]}')
 
     match = Rever.search(icps)
     assert match.group() == Vstrings.json.encode("utf-8")
@@ -404,7 +404,7 @@ def test_serials():
                     b'","sn":"0001","ilk":"rot","dig":"DVPzhzS6b5CMaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAf'
                     b'S","sith":1,"keys":["AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"],"next":"'
                     b'DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM","toad":0,"cuts":[],"adds":[],"'
-                    b'data":[],"sigs":[0]}')
+                    b'data":[],"idxs":[0]}')
 
     match = Rever.search(rots)
     assert match.group() == Vstrings.json.encode("utf-8")
@@ -416,7 +416,7 @@ def test_serials():
                     b'VPzhzS6b5CM\xa2sn\xa40001\xa3ilk\xa3icp\xa3dig\xd9,DVPzhzS6b5CMaU6JR2nmwyZ'
                     b'-i0d8JZAoTNZH3ULvYAfS\xa4sith\x01\xa4keys\x91\xd9,AaU6JR2nmwyZ-i0d8JZAoTNZH'
                     b'3ULvYAfSVPzhzS6b5CM\xa4next\xd9,DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5'
-                    b'CM\xa4toad\x00\xa4wits\x90\xa4data\x90\xa4sigs\x91\x00')
+                    b'CM\xa4toad\x00\xa4wits\x90\xa4data\x90\xa4idxs\x91\x00')
 
     match = Rever.search(icps)
     assert match.group() == Vstrings.mgpk.encode("utf-8")
@@ -428,7 +428,7 @@ def test_serials():
                     b'VPzhzS6b5CM\xa2sn\xa40001\xa3ilk\xa3rot\xa3dig\xd9,DVPzhzS6b5CMaU6JR2nmwyZ'
                     b'-i0d8JZAoTNZH3ULvYAfS\xa4sith\x01\xa4keys\x91\xd9,AaU6JR2nmwyZ-i0d8JZAoTNZH'
                     b'3ULvYAfSVPzhzS6b5CM\xa4next\xd9,DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5'
-                    b'CM\xa4toad\x00\xa4cuts\x90\xa4adds\x90\xa4data\x90\xa4sigs\x91\x00')
+                    b'CM\xa4toad\x00\xa4cuts\x90\xa4adds\x90\xa4data\x90\xa4idxs\x91\x00')
 
     match = Rever.search(rots)
     assert match.group() == Vstrings.mgpk.encode("utf-8")
@@ -439,7 +439,7 @@ def test_serials():
     assert icps == (b'\xacbvsqKERI10CBOR000000_bidx,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CMb'
                     b'snd0001cilkcicpcdigx,DVPzhzS6b5CMaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSdsith\x01d'
                     b'keys\x81x,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CMdnextx,DZ-i0d8JZAoTNZ'
-                    b'H3ULvaU6JR2nmwyYAfSVPzhzS6b5CMdtoad\x00dwits\x80ddata\x80dsigs\x81\x00')
+                    b'H3ULvaU6JR2nmwyYAfSVPzhzS6b5CMdtoad\x00dwits\x80ddata\x80didxs\x81\x00')
 
     match = Rever.search(icps)
     assert match.group() == Vstrings.cbor.encode("utf-8")
@@ -450,7 +450,7 @@ def test_serials():
     assert rots == (b'\xadbvsqKERI10CBOR000000_bidx,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CMb'
                     b'snd0001cilkcrotcdigx,DVPzhzS6b5CMaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSdsith\x01d'
                     b'keys\x81x,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CMdnextx,DZ-i0d8JZAoTNZ'
-                    b'H3ULvaU6JR2nmwyYAfSVPzhzS6b5CMdtoad\x00dcuts\x80dadds\x80ddata\x80dsigs\x81'
+                    b'H3ULvaU6JR2nmwyYAfSVPzhzS6b5CMdtoad\x00dcuts\x80dadds\x80ddata\x80didxs\x81'
                     b'\x00')
 
     match = Rever.search(rots)
@@ -991,7 +991,7 @@ def test_process_nontransferable():
                 toad="{:x}".format(toad),  # hex string no leading zeros lowercase
                 wits=[],  # list of qual Base64 may be empty
                 data=[],  # list of config ordered mappings may be empty
-                sigs="{:x}".format(nsigs)  # single lowercase hex string
+                idxs="{:x}".format(nsigs)  # single lowercase hex string
                )
 
     # verify derivation of aid0 from ked0
@@ -1016,11 +1016,11 @@ def test_process_nontransferable():
     del msgb0[:rser0.size]  # strip off event from front
 
     # extract attached sigs if any
-    if "sigs" not in rser0.ked or not rser0.ked["sigs"]:  # no info on attached sigs
+    if "idxs" not in rser0.ked or not rser0.ked["idxs"]:  # no info on attached sigs
         assert False
 
     else:
-        ridxs = rser0.ked["sigs"]  # exract signature indexes
+        ridxs = rser0.ked["idxs"]  # exract signature indexes
         if isinstance(ridxs, list):
             for idx in ridxs:
                 pass
@@ -1081,7 +1081,7 @@ def test_process_transferable():
                 toad="{:x}".format(toad),  # hex string no leading zeros lowercase
                 wits=[],  # list of qual Base64 may be empty
                 data=[],  # list of config ordered mappings may be empty
-                sigs="{:x}".format(nsigs)  # single lowercase hex string
+                idxs="{:x}".format(nsigs)  # single lowercase hex string
                )
 
 
@@ -1110,12 +1110,12 @@ def test_process_transferable():
 
     del msgb0[:rser0.size]  # strip off event from front
 
-    # extract attached sigs if any
-    if "sigs" not in rser0.ked or not rser0.ked["sigs"]:  # no info on attached sigs
+    # extract attached idxs if any
+    if "idxs" not in rser0.ked or not rser0.ked["idxs"]:  # no info on attached idxs
         assert False
 
     else:
-        ridxs = rser0.ked["sigs"]  # exract signature indexes
+        ridxs = rser0.ked["idxs"]  # exract signature indexes
         if isinstance(ridxs, list):
             for idx in ridxs:
                 pass
@@ -1212,7 +1212,7 @@ def test_process_manual():
                 toad="{:x}".format(toad),  # hex string no leading zeros lowercase
                 wits=[],  # list of qual Base64 may be empty
                 data=[],  # list of config ordered mappings may be empty
-                sigs=["{:x}".format(index)]  # optional list of lowercase hex strings no leading zeros or single lowercase hex string
+                idxs=["{:x}".format(index)]  # optional list of lowercase hex strings no leading zeros or single lowercase hex string
                )
 
 
@@ -1220,13 +1220,13 @@ def test_process_manual():
     assert txsrdr.raw == (b'{"vs":"KERI10JSON000108_","id":"Dr5awcPswp9CkGMncHYbCOpj3P3Qb3i7MyzuKsKJP50s'
                           b'","sn":"0","ilk":"icp","sith":"1","keys":["Dr5awcPswp9CkGMncHYbCOpj3P3Qb3i7M'
                           b'yzuKsKJP50s"],"next":"E3ld50z3LYM7pmQxG3bJDNgOnRg1T1v5tmYmsYDyqiNI","toad":"'
-                          b'0","wits":[],"data":[],"sigs":["0"]}')
+                          b'0","wits":[],"data":[],"idxs":["0"]}')
 
     assert txsrdr.size == 264
 
     txdig = blake3.blake3(txsrdr.raw).digest()
     txdigmat = CryMat(raw=txdig, code=CryOne.Blake3_256)
-    assert txdigmat.qb64 == 'EGt8ffYFN2qVZ_6n7mVElKUGayCHjCzsTllwxhyy1OBg'
+    assert txdigmat.qb64 == 'EzTKQVe4DVmx9rZBPg70sypOoEYf6QROSinSoFfIbrDM'
 
     assert txsrdr.dig == txdigmat.qb64
 
@@ -1237,7 +1237,7 @@ def test_process_manual():
     assert not result  # None if verifies successfully else raises ValueError
 
     txsigmat = SigMat(raw=sig0raw, code=SigTwo.Ed25519, index=index)
-    assert txsigmat.qb64 == 'AAMtdYrJ7xGyvMYYw2Km8SQd0rKJwPeB24Mebcw2bQk30tX1lk49krbChHy7xooq-DIKvf7FLoBvUdQ1mTqTRTCg'
+    assert txsigmat.qb64 == 'AA0eSN02MaVpKer6BEBiBgkK6PmprPinJsZFRr5CAd0XiViWlJrPy1oyitaIibULo2Zx8Ff2KRakHGyu7Ht3nBCg'
     assert len(txsigmat.qb64) == 88
     assert txsigmat.index == index
 
@@ -1264,7 +1264,7 @@ def test_process_manual():
     rxvermat = CryMat(qb64=rxverqb64)
     assert rxvermat.qb64 == rxaidmat.qb64  #  basic derivation same
 
-    indexes = [ int(index, 16) for index in rxsrdr.ked["sigs"]]
+    indexes = [ int(index, 16) for index in rxsrdr.ked["idxs"]]
     assert indexes == [0]
     assert indexes[0] == rxsigmat.index
 

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -930,6 +930,15 @@ def test_aider():
 def test_kever():
     """
     Test the support functionality for Kever class
+    Key Event Verifier
+    """
+    kever = Kever()
+    """ Done Test """
+
+def test_keger():
+    """
+    Test the support functionality for Keger class
+    Key Event Generator
     """
     kever = Kever()
     """ Done Test """

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -939,12 +939,12 @@ def test_kever():
     kever = Kever()
     """ Done Test """
 
-def test_kevery():
+def test_skevery():
     """
     Test the support functionality for Kevery factory class
     Key Event Verifier Factory
     """
-    kevery = Skevery()
+    skevery = Skevery()
     """ Done Test """
 
 def test_keger():

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -29,7 +29,7 @@ from keri.core.coring import SigMat
 from keri.core.coring import Serialage, Serials, Mimes, Vstrings
 from keri.core.coring import Versify, Deversify, Rever
 from keri.core.coring import Serder
-from keri.core.coring import Ilkage, Ilks, Corver
+from keri.core.coring import Ilkage, Ilks, Kever
 
 
 def test_cryderivationcodes():
@@ -91,13 +91,7 @@ def test_cryderivationcodes():
               '1AAA', '1AAB']:
         assert x in CrySizes
         assert x in CryRawSizes
-
-
-
-
-    """
-    Done Test
-    """
+    """Done Test"""
 
 def test_sigderivationcodes():
     """
@@ -142,11 +136,7 @@ def test_sigderivationcodes():
     for x in ['A', 'B', '0A']:
         assert x in SigSizes
         assert x in SigRawSizes
-
-
-    """
-    Done Test
-    """
+    """Done Test"""
 
 def test_crymat():
     """
@@ -339,8 +329,6 @@ def test_sigmat():
     assert sigmat.raw == sig
     assert sigmat.code == SigTwo.Ed25519
     assert sigmat.index == 5
-
-
     """ Done Test """
 
 
@@ -466,10 +454,7 @@ def test_serials():
 
     match = Rever.search(rots)
     assert match.group() == Vstrings.cbor.encode("utf-8")
-
-    """
-    Done Test
-    """
+    """Done Test"""
 
 def test_serder():
     """
@@ -646,10 +631,7 @@ def test_serder():
     assert evt2.kind == Serials.json
     knd, version, size = Deversify(evt2.ked['vs'])
     assert knd == Serials.json
-
-    """
-    Done Test
-    """
+    """Done Test """
 
 def test_ilks():
     """
@@ -708,8 +690,6 @@ def test_verifier():
 
     with pytest.raises(ValueError):
         verfer = Verifier(raw=verkey, code=CryOne.Blake3_256)
-
-
     """ Done Test """
 
 def test_signer():
@@ -795,7 +775,6 @@ def test_signer():
 
     with pytest.raises(ValueError):
         signer = Signer(code=CryOne.Ed25519N)
-
     """ Done Test """
 
 def test_digester():
@@ -834,7 +813,6 @@ def test_digester():
 
     with pytest.raises(ValueError):
         digester = Digester(ser=ser, code=CryOne.Ed25519)
-
     """ Done Test """
 
 def test_nexter():
@@ -893,9 +871,6 @@ def test_nexter():
     assert nexter.verify(ser=ser)
     assert nexter.verify(ser=ser+b'ABCDEF') == False
     assert nexter.verify(ked=ked)
-
-
-
     """ Done Test """
 
 
@@ -950,10 +925,15 @@ def test_aider():
     ked = dict(keys=[verifier.qb64], next="ABCD")
     with pytest.raises(DerivationError):
         aider = Aider(ked=ked)
-
-
-
     """ Done Test """
+
+def test_kever():
+    """
+    Test the support functionality for Kever class
+    """
+    kever = Kever()
+    """ Done Test """
+
 
 def test_process_nontransferable():
     """
@@ -1038,7 +1018,6 @@ def test_process_nontransferable():
     # verify aid
     raid0 = Aider(qb64=rser0.ked["id"])
     assert raid0.verify(ked=rser0.ked)
-
     """ Done Test """
 
 def test_process_transferable():
@@ -1138,8 +1117,6 @@ def test_process_transferable():
     #verify nxt digest from event is still valid
     rnext1 = Nexter(qb64=rser0.ked["next"])
     assert rnext1.verify(sith=nxtsith, keys=nxtkeys)
-
-
     """ Done Test """
 
 
@@ -1148,9 +1125,6 @@ def test_process_manual():
     """
     Test manual process of generating and validating inception key event message
     """
-    with pytest.raises(ValueError):
-        corver = Corver()
-
     # create qualified aid in basic format
     # workflow is start with seed and save seed. Seed in this case is 32 bytes
     # aidseed = pysodium.randombytes(pysodium.crypto_sign_SEEDBYTES)
@@ -1272,9 +1246,7 @@ def test_process_manual():
 
     result = pysodium.crypto_sign_verify_detached(rxsigmat.raw, rxsrdr.raw, rxvermat.raw)
     assert not result  # None if verifies successfully else raises ValueError
-
-
     """ Done Test """
 
 if __name__ == "__main__":
-    test_nexter()
+    test_kever()

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -30,7 +30,7 @@ from keri.core.coring import Serialage, Serials, Mimes, Vstrings
 from keri.core.coring import Versify, Deversify, Rever
 from keri.core.coring import Serder
 from keri.core.coring import Ilkage, Ilks
-from keri.core.coring import Kever, Kevery, Keger
+from keri.core.coring import Kever, Skevery, Keger
 
 
 def test_cryderivationcodes():
@@ -944,7 +944,7 @@ def test_kevery():
     Test the support functionality for Kevery factory class
     Key Event Verifier Factory
     """
-    kevery = Kevery()
+    kevery = Skevery()
     """ Done Test """
 
 def test_keger():

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -853,10 +853,10 @@ def test_aider():
     assert len(aider.qb64) == CryOneSizes[aider.code]
 
     iked = dict(keys=[aider.qb64], next="")
-    assert aider.verify(iked=iked) == True
+    assert aider.verify(ked=iked) == True
 
     iked = dict(keys=[aider.qb64], next="ABC")
-    assert aider.verify(iked=iked) == False
+    assert aider.verify(ked=iked) == False
 
     aider = Aider(raw=verkey, code=CryOne.Ed25519)  # defaults provide Ed25519N aider
     assert aider.code == CryOne.Ed25519
@@ -864,12 +864,12 @@ def test_aider():
     assert len(aider.qb64) == CryOneSizes[aider.code]
 
     iked = dict(keys=[aider.qb64])
-    assert aider.verify(iked=iked) == True
+    assert aider.verify(ked=iked) == True
 
     verifier = Verifier(raw=verkey, code=CryOne.Ed25519)
     aider = Aider(raw=verifier.raw)
     assert aider.code == CryOne.Ed25519N
-    assert aider.verify(iked=iked) == False
+    assert aider.verify(ked=iked) == False
 
     """ Done Test """
 
@@ -909,7 +909,7 @@ def test_process():
                )
 
     # verify derivation of aid0 from ked0
-    assert aid0.verify(iked=ked0)
+    assert aid0.verify(ked=ked0)
 
     # Serialize ked0
     tser0 = Serder(ked=ked0)
@@ -955,7 +955,7 @@ def test_process():
 
     # verify aid
     raid0 = Aider(qb64=rser0.ked["id"])
-    assert raid0.verify(iked=rser0.ked)
+    assert raid0.verify(ked=rser0.ked)
 
     # Transferable case
     skip0 = Signer()  #  original signing keypair transferable default

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -490,9 +490,10 @@ def test_serder():
     assert kind1 == Serials.json
     assert size1 == 65
     e1ss = e1s + b'extra attached at the end.'
-    ked1, knd1, siz1 = serder._inhale(e1ss)
+    ked1, knd1, vrs1, siz1 = serder._inhale(e1ss)
     assert ked1 == e1
     assert knd1 == kind1
+    assert vrs1 == vers1
     assert siz1 == size1
 
     raw1, knd1, ked1 = serder._exhale(ked=e1)
@@ -511,9 +512,10 @@ def test_serder():
     assert kind2 == Serials.mgpk
     assert size2 == 49
     e2ss = e2s + b'extra attached  at the end.'
-    ked2, knd2, siz2 = serder._inhale(e2ss)
+    ked2, knd2, vrs2, siz2 = serder._inhale(e2ss)
     assert ked2 == e2
     assert knd2 == kind2
+    assert vrs2 == vers2
     assert siz2 == size2
 
     raw2, knd2, ked2 = serder._exhale(ked=e2)
@@ -532,9 +534,10 @@ def test_serder():
     assert kind3 == Serials.cbor
     assert size3 == 49
     e3ss = e3s + b'extra attached  at the end.'
-    ked3, knd3, siz3 = serder._inhale(e3ss)
+    ked3, knd3, vrs3, siz3 = serder._inhale(e3ss)
     assert ked3 == e3
     assert knd3 == kind3
+    assert vrs3 == vers3
     assert siz3 == size3
 
     raw3, knd3, ked3 = serder._exhale(ked=e3)

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -30,7 +30,7 @@ from keri.core.coring import Serialage, Serials, Mimes, Vstrings
 from keri.core.coring import Versify, Deversify, Rever
 from keri.core.coring import Serder
 from keri.core.coring import Ilkage, Ilks
-from keri.core.coring import Kever, Skevery, Keger
+from keri.core.coring import Kever, Kevery, Keger
 
 
 def test_cryderivationcodes():
@@ -931,20 +931,23 @@ def test_aider():
         aider = Aider(ked=ked)
     """ Done Test """
 
+
+
+def test_kevery():
+    """
+    Test the support functionality for Kevery factory class
+    Key Event Verifier Factory
+    """
+    kevery = Kevery()
+    """ Done Test """
+
 def test_kever():
     """
     Test the support functionality for Kever class
     Key Event Verifier
     """
-    kever = Kever()
-    """ Done Test """
-
-def test_skevery():
-    """
-    Test the support functionality for Kevery factory class
-    Key Event Verifier Factory
-    """
-    skevery = Skevery()
+    with pytest.raises(TypeError):
+        kever = Kever()
     """ Done Test """
 
 def test_keger():
@@ -952,7 +955,7 @@ def test_keger():
     Test the support functionality for Keger class
     Key Event Generator
     """
-    kever = Kever()
+    keger = Keger()
     """ Done Test """
 
 


### PR DESCRIPTION
Building the framework for verifying and validating KERI events.

Changed a couple of field element labels to be less confusing.

all events "sigs" to "ides"
inception "data" to inception "conf"

