### PR TITLE
Remove "ids" element in events

### DIFF
--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -1007,12 +1007,50 @@ class SigSelectCodex:
     """
     four: str = '0'  # use four character table.
     five: str = '1'  # use five character table.
-    six:  str = '2'  # use siz character table.
+    six:  str = '2'  # use six character table.
+    dash:  str = '-'  # use signature count table
 
     def __iter__(self):
         return iter(astuple(self))
 
 SigSelDex = SigSelectCodex()  # Make instance
+
+
+
+@dataclass(frozen=True)
+class SigCntCodex:
+    """
+    SigCntCodex codex of four character length derivation codes that indicate
+    count (number) of attached signatures following an event .
+    Only provide defined codes.
+    Undefined are left out so that inclusion(exclusion) via 'in' operator works.
+
+    Note binary length of everything in SigCntCodex results in 0 Base64 pad bytes.
+
+    First two code characters select format of attached signatures
+    Next two code charaters select count total of attached signatures to an event
+    Only provide first two characters here
+    """
+    Base64: str =  '-A'  # Fully Qualified Base64 Format Signatures.
+    Base64: str =  '-B'  # Fully Qualified Base2 Format Signatures.
+
+    def __iter__(self):
+        return iter(astuple(self))
+
+SigCntDex = SigCntCodex()  #  Make instance
+
+# Mapping of Code to Size
+SigCntSizes = {
+                "-A": 4,
+                "-B": 4,
+               }
+
+SigCntRawSizes = {
+                "-A": 3,
+                "-B": 3,
+               }
+
+SIGCNTMAX = 4095  # maximum count value given two base 64 digits
 
 
 @dataclass(frozen=True)
@@ -1101,6 +1139,7 @@ class SigFiveCodex:
 
 SigFiveDex = SigFiveCodex()  #  Make instance
 
+
 # Mapping of Code to Size
 SigFiveSizes = {}
 SigFiveRawSizes = {}
@@ -1108,11 +1147,14 @@ SigFiveRawSizes = {}
 SIGFIVEMAX = 4095  # maximum index value given two base 64 digits
 
 # all sizes in one dict
-SigSizes = dict(SigTwoSizes)
+SigSizes = dict(SigCntSizes)
+SigSizes.update(SigTwoSizes)
 SigSizes.update(SigFourSizes)
 SigSizes.update(SigFiveSizes)
 
-SigRawSizes = dict(SigTwoRawSizes)
+
+SigRawSizes = dict(SigCntRawSizes)
+SigRawSizes.update(SigTwoRawSizes)
 SigRawSizes.update(SigFourRawSizes)
 SigRawSizes.update(SigFiveRawSizes)
 
@@ -1154,7 +1196,7 @@ class SigMat:
                 raise TypeError("Not a bytes or bytearray, raw={}.".format(raw))
             pad = self._pad(raw)
             if (not ( (pad == 2 and (code in SigTwoDex)) or  # Two or Six or Ten
-                      (pad == 0 and (code in SigFourDex)) or  #  Four or Eight
+                      (pad == 0 and (code in SigFourDex)) or  # Four or Eight
                       (pad == 1 and (code in SigFiveDex)) )):   # Five or Nine
 
                 raise ValidationError("Wrong code={} for raw={}.".format(code, raw))

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -1031,6 +1031,7 @@ class SigCntCodex:
     count (number) of attached signatures following an event .
     Only provide defined codes.
     Undefined are left out so that inclusion(exclusion) via 'in' operator works.
+    .raw is empty
 
     Note binary length of everything in SigCntCodex results in 0 Base64 pad bytes.
 
@@ -1039,7 +1040,7 @@ class SigCntCodex:
     Only provide first two characters here
     """
     Base64: str =  '-A'  # Fully Qualified Base64 Format Signatures.
-    Base64: str =  '-B'  # Fully Qualified Base2 Format Signatures.
+    Base2:  str =  '-B'  # Fully Qualified Base2 Format Signatures.
 
     def __iter__(self):
         return iter(astuple(self))

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -691,12 +691,12 @@ class Kevery:
     Properties:
 
     """
-    def __init__(self, exhaustive=True):
+    def __init__(self, framed=True):
         """
         Set up event stream
 
         """
-        self.exhaustive = True if exhaustive else False  # extract until end-of-stream
+        self.framed = True if framed else False  # extract until end-of-stream
 
 
     def extractOne(self, kes, framed=True):

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -75,7 +75,6 @@ def incept( keys,
             toad=None,
             wits=None,
             cnfg=None,
-            idxs=None
           ):
 
     """
@@ -91,9 +90,6 @@ def incept( keys,
         toad
         wits
         cnfg
-        idxs
-
-
     """
     vs = Versify(version=version, kind=kind, size=0)
     sn = 0
@@ -139,11 +135,6 @@ def incept( keys,
                cnfg=cnfg,  # list of config ordered mappings may be empty
                )
 
-    if idxs is not None:  # add idxs element to ked
-        if isinstance(idxs, int):
-            idxs="{:x}".format(nsigs)  # single lowercase hex string
-        ked["idxs"] = idxs  # update ked with idxs field
-
     # raises derivation error if non-empty nxt but ephemeral code
     aider = Aider(ked=ked)  # Derive AID from ked
     ked["aid"] = aider.qb64  # update aid element in ked with aid qb64
@@ -164,7 +155,6 @@ def rotate( aid,
             cuts=None,
             adds=None,
             data=None,
-            idxs=None
           ):
 
     """
@@ -184,9 +174,6 @@ def rotate( aid,
         cuts
         adds
         data
-        idxs
-
-
     """
     vs = Versify(version=version, kind=kind, size=0)
     ilk = Ilks.rot
@@ -265,11 +252,6 @@ def rotate( aid,
                data=data,  # list of seals
                )
 
-    if idxs is not None:  # add idxs element to ked
-        if isinstance(idxs, int):
-            idxs="{:x}".format(nsigs)  # single lowercase hex string
-        ked["idxs"] = idxs  # update ked with idxs field
-
     return Serder(ked=ked)  # return serialized ked
 
 
@@ -279,7 +261,6 @@ def interact( aid,
               kind=Serials.json,
               sn=1,
               data=None,
-              idxs=None
           ):
 
     """
@@ -293,9 +274,6 @@ def interact( aid,
         kind
         sn
         data
-        idxs
-
-
     """
     vs = Versify(version=version, kind=kind, size=0)
     ilk = Ilks.ixn
@@ -312,11 +290,6 @@ def interact( aid,
                dig=dig,
                data=data,  # list of seals
                )
-
-    if idxs is not None:  # add idxs element to ked
-        if isinstance(idxs, int):
-            idxs="{:x}".format(nsigs)  # single lowercase hex string
-        ked["idxs"] = idxs  # update ked with idxs field
 
     return Serder(ked=ked)  # return serialized ked
 
@@ -709,7 +682,7 @@ class Kevery:
                 May contain one or more sets each of a serialized event with
                 attached signatures.
 
-            framed is Boolean, If True and no idxs in serder then extract signatures
+            framed is Boolean, If True and no sig counter then extract signatures
                 until end-of-stream. This is useful for framed packets with
                 one event and one set of attached signatures per invocation.
 
@@ -728,43 +701,24 @@ class Kevery:
 
         del kes[:srdr.size]  # strip off event from front of kes
 
-        # extract attached sigs as Sigxers
+        # extact sig counter if any
+        try:
+            counter = SigCounter(qb64=kes)  # qb64
+            nsigs = counter.count
+            del kes[:len(counter.qb64)]  # strip off counter
+        except ValidationError as ex:
+            nsigs = 0  # no signature count
+
+        # extract attached sigs as Sigers
         sigers = []  # list of Siger instances for attached indexed signatures
-        if "idxs" in ked and ked["idxs"]: # extract signatures given indexes
-            indexes = ked["idxs"]
-            if isinstance(indexes, str):
-                nsigs = int(indexes, 16)
-                if nsigs < 1:
-                    raise ValidationError("Invalid number of attached sigs = {}."
-                                              " Must be > 1 if not empty.".format(nsigs))
-
-                for i in range(nsigs): # extract each attached signature
-                    # check here for type of attached signatures qb64 or qb2
-                    siger = Siger(qb64=kes)  # qb64
-                    sigers.append(siger)
-                    del kes[:len(siger.qb64)]  # strip off signature
-
-            elif isinstance(indexes, list):
-                if len(set(indexes)) != len(indexes):  # duplicate index(es)
-                    raise ValidationError("Duplicate indexes in sigs = {}."
-                                              "".format(indexes))
-
-                for index in indexes:
-                    # check here for type of attached signatures qb64 or qb2
-                    siger = Siger(qb64=kes)  # qb64
-                    sigers.append(siger)
-                    del kes[:len(siger.qb64)]  # strip off signature
-
-                    if index != siger.index:
-                        raise ValidationError("Mismatching signature index = {}"
-                                              " with index = {}".format(siger.index,
-                                                                        index))
-            else:
-                raise ValidationError("Invalid format of indexes = {}."
-                                          "".format(indexes))
+        if nsigs:
+            for i in range(nsigs): # extract each attached signature
+                # check here for type of attached signatures qb64 or qb2
+                siger = Siger(qb64=kes)  # qb64
+                sigers.append(siger)
+                del kes[:len(siger.qb64)]  # strip off signature
 
         else:  # no info on attached sigs
-            #  add ability to parse for index block
             if framed:  # parse for signatures until end-of-stream
                 while kes:
                     # check here for type of attached signatures qb64 or qb2
@@ -873,6 +827,7 @@ class Kevery:
             except Exception as  ex:
                 # log diagnostics errors etc
                 continue
+
 
     def duplicity(self, serder, sigers):
         """

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -861,7 +861,7 @@ class Kevery:
 
         while kes:
             try:
-                serder, sigers = self.extractOne(kes=kes)
+                serder, sigers = self.extractOne(kes=kes, framed=self.framed)
             except Exception as ex:
                 # log diagnostics errors etc
                 # error extracting means bad key event stream

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -597,10 +597,30 @@ def test_sigmat():
     assert SigTwoSizes[SigTwoDex.Ed25519] == 88
     assert SigTwoSizes[SigTwoDex.ECDSA_256k1] == 88
 
+    cs = IntToB64(27)
+    assert cs == "b"
+    i = B64ToInt(cs)
+    assert i == 27
+
     cs = IntToB64(80)
     assert cs == "BQ"
     i = B64ToInt(cs)
-    assert i ==  80
+    assert i == 80
+
+    cs = IntToB64(4095)
+    assert cs == '__'
+    i = B64ToInt(cs)
+    assert i == 4095
+
+    cs = IntToB64(4096)
+    assert cs == 'BAA'
+    i = B64ToInt(cs)
+    assert i == 4096
+
+    cs = IntToB64(6011)
+    assert cs == "Bd7"
+    i = B64ToInt(cs)
+    assert i == 6011
 
     sig = (b"\x99\xd2<9$$0\x9fk\xfb\x18\xa0\x8c@r\x122.k\xb2\xc7\x1fp\x0e'm\x8f@"
            b'\xaa\xa5\x8c\xc8n\x85\xc8!\xf6q\x91p\xa9\xec\xcf\x92\xaf)\xde\xca'

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -860,7 +860,6 @@ def test_serials():
               toad = 0,
               wits = [],
               cnfg = [],
-              idxs = [0]
              )
 
     rot = dict(vs = Vstrings.json,
@@ -875,51 +874,51 @@ def test_serials():
               cuts = [],
               adds = [],
               data = [],
-              idxs = [0]
              )
 
     icps = json.dumps(icp, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
-    assert len(icps) == 314
+    assert len(icps) == 303
     assert icps == (b'{"vs":"KERI10JSON000000_","aid":"AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM'
                     b'","sn":"0001","ilk":"icp","dig":"DVPzhzS6b5CMaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAf'
                     b'S","sith":1,"keys":["AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"],"nxt":"'
-                    b'DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM","toad":0,"wits":[],"cnfg":[],"'
-                    b'idxs":[0]}')
+                    b'DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM","toad":0,"wits":[],"cnfg":[]}')
 
     match = Rever.search(icps)
     assert match.group() == Vstrings.json.encode("utf-8")
 
     rots = json.dumps(rot, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
-    assert len(rots) == 324
+    assert len(rots) == 313
     assert rots == (b'{"vs":"KERI10JSON000000_","aid":"AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM'
                     b'","sn":"0001","ilk":"rot","dig":"DVPzhzS6b5CMaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAf'
                     b'S","sith":1,"keys":["AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"],"nxt":"'
                     b'DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM","toad":0,"cuts":[],"adds":[],"'
-                    b'data":[],"idxs":[0]}')
+                    b'data":[]}')
 
     match = Rever.search(rots)
     assert match.group() == Vstrings.json.encode("utf-8")
 
     icp["vs"] = Vstrings.mgpk
     icps = msgpack.dumps(icp)
-    assert len(icps) == 271
-    assert icps == (b'\x8c\xa2vs\xb1KERI10MGPK000000_\xa3aid\xd9,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAf'
+    assert len(icps) == 264
+    assert icps == (b'\x8b\xa2vs\xb1KERI10MGPK000000_\xa3aid\xd9,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAf'
                     b'SVPzhzS6b5CM\xa2sn\xa40001\xa3ilk\xa3icp\xa3dig\xd9,DVPzhzS6b5CMaU6JR2nmwy'
                     b'Z-i0d8JZAoTNZH3ULvYAfS\xa4sith\x01\xa4keys\x91\xd9,AaU6JR2nmwyZ-i0d8JZAoTNZ'
                     b'H3ULvYAfSVPzhzS6b5CM\xa3nxt\xd9,DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5'
-                    b'CM\xa4toad\x00\xa4wits\x90\xa4cnfg\x90\xa4idxs\x91\x00')
+                    b'CM\xa4toad\x00\xa4wits\x90\xa4cnfg\x90')
+
 
     match = Rever.search(icps)
     assert match.group() == Vstrings.mgpk.encode("utf-8")
 
     rot["vs"] = Vstrings.mgpk
     rots = msgpack.dumps(rot)
-    assert len(rots) == 277
-    assert rots == (b'\x8d\xa2vs\xb1KERI10MGPK000000_\xa3aid\xd9,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAf'
+    assert len(rots) == 270
+    assert rots == (b'\x8c\xa2vs\xb1KERI10MGPK000000_\xa3aid\xd9,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAf'
                     b'SVPzhzS6b5CM\xa2sn\xa40001\xa3ilk\xa3rot\xa3dig\xd9,DVPzhzS6b5CMaU6JR2nmwy'
                     b'Z-i0d8JZAoTNZH3ULvYAfS\xa4sith\x01\xa4keys\x91\xd9,AaU6JR2nmwyZ-i0d8JZAoTNZ'
                     b'H3ULvYAfSVPzhzS6b5CM\xa3nxt\xd9,DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5'
-                    b'CM\xa4toad\x00\xa4cuts\x90\xa4adds\x90\xa4data\x90\xa4idxs\x91\x00')
+                    b'CM\xa4toad\x00\xa4cuts\x90\xa4adds\x90\xa4data\x90')
+
 
 
     match = Rever.search(rots)
@@ -927,23 +926,23 @@ def test_serials():
 
     icp["vs"] = Vstrings.cbor
     icps = cbor.dumps(icp)
-    assert len(icps) == 271
-    assert icps == (b'\xacbvsqKERI10CBOR000000_caidx,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM'
-                    b'bsnd0001cilkcicpcdigx,DVPzhzS6b5CMaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSdsith\x01'
-                    b'dkeys\x81x,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CMcnxtx,DZ-i0d8JZAoTNZ'
-                    b'H3ULvaU6JR2nmwyYAfSVPzhzS6b5CMdtoad\x00dwits\x80dcnfg\x80didxs\x81\x00')
+    assert len(icps) == 264
+    assert icps == (b'\xabbvsqKERI10CBOR000000_caidx,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM'
+                     b'bsnd0001cilkcicpcdigx,DVPzhzS6b5CMaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSdsith\x01'
+                     b'dkeys\x81x,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CMcnxtx,DZ-i0d8JZAoTNZ'
+                     b'H3ULvaU6JR2nmwyYAfSVPzhzS6b5CMdtoad\x00dwits\x80dcnfg\x80')
+
 
     match = Rever.search(icps)
     assert match.group() == Vstrings.cbor.encode("utf-8")
 
     rot["vs"] = Vstrings.cbor
     rots = cbor.dumps(rot)
-    assert len(rots) == 277
-    assert rots == (b'\xadbvsqKERI10CBOR000000_caidx,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM'
+    assert len(rots) == 270
+    assert rots == (b'\xacbvsqKERI10CBOR000000_caidx,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM'
                     b'bsnd0001cilkcrotcdigx,DVPzhzS6b5CMaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSdsith\x01'
                     b'dkeys\x81x,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CMcnxtx,DZ-i0d8JZAoTNZ'
-                    b'H3ULvaU6JR2nmwyYAfSVPzhzS6b5CMdtoad\x00dcuts\x80dadds\x80ddata\x80didxs\x81'
-                    b'\x00')
+                    b'H3ULvaU6JR2nmwyYAfSVPzhzS6b5CMdtoad\x00dcuts\x80dadds\x80ddata\x80')
 
     match = Rever.search(rots)
     assert match.group() == Vstrings.cbor.encode("utf-8")

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -607,6 +607,11 @@ def test_sigmat():
     i = B64ToInt(cs)
     assert i == 27
 
+    cs = IntToB64(27, l=2)
+    assert cs == "Ab"
+    i = B64ToInt(cs)
+    assert i == 27
+
     cs = IntToB64(80)
     assert cs == "BQ"
     i = B64ToInt(cs)
@@ -1060,4 +1065,4 @@ def test_serder():
 
 
 if __name__ == "__main__":
-    test_siger()
+    test_sigmat()

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -598,7 +598,7 @@ def test_sigmat():
     assert SigTwoSizes[SigTwoDex.ECDSA_256k1] == 88
 
     cs = IntToB64(80)
-    assert cs ==  "BQ"
+    assert cs == "BQ"
     i = B64ToInt(cs)
     assert i ==  80
 

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -29,7 +29,7 @@ from keri.core.coring import SigFourDex, SigFourSizes, SigFourRawSizes
 from keri.core.coring import SigFiveDex, SigFiveSizes, SigFiveRawSizes
 from keri.core.coring import SigSizes, SigRawSizes
 from keri.core.coring import IntToB64, B64ToInt
-from keri.core.coring import SigMat, Siger
+from keri.core.coring import SigMat, SigCounter, Siger
 from keri.core.coring import Serialage, Serials, Mimes, Vstrings
 from keri.core.coring import Versify, Deversify, Rever
 from keri.core.coring import Serder
@@ -644,6 +644,13 @@ def test_sigmat():
     assert sigmat.qb64 == qsc
     assert sigmat.qb2 == b'\xf8\x00\x00'
 
+    sigmat = SigMat(qb64=qsc)
+    assert sigmat.raw == b''
+    assert sigmat.code == SigCntDex.Base64
+    assert sigmat.index == 0
+    assert sigmat.qb64 == qsc
+    assert sigmat.qb2 == b'\xf8\x00\x00'
+
     idx = 5
     qsc = SigCntDex.Base64 + IntToB64(idx, l=2)
     assert qsc == '-AAF'
@@ -734,6 +741,60 @@ def test_sigmat():
     assert sigmat.raw == sig
     assert sigmat.code == SigTwoDex.Ed25519
     assert sigmat.index == 5
+    """ Done Test """
+
+def test_sigcounter():
+    """
+    Test SigCounter subclass of Sigmat
+    """
+    with pytest.raises(EmptyMaterialError):
+        counter = SigCounter()
+
+    qsc = SigCntDex.Base64 + IntToB64(0, l=2)
+    assert qsc == '-AAA'
+
+    counter = SigCounter(raw=b'')
+    assert counter.raw == b''
+    assert counter.code == SigCntDex.Base64
+    assert counter.index == 0
+    assert counter.count == 0
+    assert counter.qb64 == qsc
+    assert counter.qb2 == b'\xf8\x00\x00'
+
+    counter = SigCounter(qb64=qsc)
+    assert counter.raw == b''
+    assert counter.code == SigCntDex.Base64
+    assert counter.index == 0
+    assert counter.count == 0
+    assert counter.qb64 == '-AAA'
+    assert counter.qb2 == b'\xf8\x00\x00'
+
+    counter = SigCounter(raw=b'', count=0)
+    assert counter.raw == b''
+    assert counter.code == SigCntDex.Base64
+    assert counter.index == 0
+    assert counter.qb64 == qsc
+    assert counter.qb2 == b'\xf8\x00\x00'
+
+    cnt = 5
+    qsc = SigCntDex.Base64 + IntToB64(cnt, l=2)
+    assert qsc == '-AAF'
+    counter = SigCounter(raw=b'', count=cnt)
+    assert counter.raw == b''
+    assert counter.code == SigCntDex.Base64
+    assert counter.index == cnt
+    assert counter.qb64 == qsc
+    assert counter.qb2 == b'\xf8\x00\x05'
+
+    counter = SigCounter(qb64=qsc)
+    assert counter.raw == b''
+    assert counter.code == SigCntDex.Base64
+    assert counter.index == cnt
+    assert counter.count == cnt
+    assert counter.qb64 == qsc
+    assert counter.qb2 == b'\xf8\x00\x05'
+
+
     """ Done Test """
 
 
@@ -1088,4 +1149,4 @@ def test_serder():
 
 
 if __name__ == "__main__":
-    test_sigmat()
+    test_sigcounter()

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -597,6 +597,11 @@ def test_sigmat():
     assert SigTwoSizes[SigTwoDex.Ed25519] == 88
     assert SigTwoSizes[SigTwoDex.ECDSA_256k1] == 88
 
+    cs = IntToB64(0)
+    assert cs == "A"
+    i = B64ToInt(cs)
+    assert i == 0
+
     cs = IntToB64(27)
     assert cs == "b"
     i = B64ToInt(cs)
@@ -1055,4 +1060,4 @@ def test_serder():
 
 
 if __name__ == "__main__":
-    test_nexter()
+    test_siger()

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -22,7 +22,9 @@ from keri.core.coring import CryOneSizes, CryOneRawSizes, CryTwoSizes, CryTwoRaw
 from keri.core.coring import CryFourSizes, CryFourRawSizes, CrySizes, CryRawSizes
 from keri.core.coring import CryMat, Verfer, Sigver, Signer, Diger, Nexter, Aider
 from keri.core.coring import generateSigners,  generateSecrets
-from keri.core.coring import SigSelDex, SigTwoDex, SigTwoSizes, SigTwoRawSizes
+from keri.core.coring import SigSelDex
+from keri.core.coring import SigCntDex, SigCntSizes, SigCntRawSizes
+from keri.core.coring import SigTwoDex, SigTwoSizes, SigTwoRawSizes
 from keri.core.coring import SigFourDex, SigFourSizes, SigFourRawSizes
 from keri.core.coring import SigFiveDex, SigFiveSizes, SigFiveRawSizes
 from keri.core.coring import SigSizes, SigRawSizes
@@ -632,6 +634,27 @@ def test_sigmat():
     i = B64ToInt(cs)
     assert i == 6011
 
+    # Test attached signature code (empty raw)
+    qsc = SigCntDex.Base64 + IntToB64(0, l=2)
+    assert qsc == '-AAA'
+    sigmat = SigMat(raw=b'', code=SigCntDex.Base64, index=0)
+    assert sigmat.raw == b''
+    assert sigmat.code == SigCntDex.Base64
+    assert sigmat.index == 0
+    assert sigmat.qb64 == qsc
+    assert sigmat.qb2 == b'\xf8\x00\x00'
+
+    idx = 5
+    qsc = SigCntDex.Base64 + IntToB64(idx, l=2)
+    assert qsc == '-AAF'
+    sigmat = SigMat(raw=b'', code=SigCntDex.Base64, index=idx)
+    assert sigmat.raw == b''
+    assert sigmat.code == SigCntDex.Base64
+    assert sigmat.index == 5
+    assert sigmat.qb64 == qsc
+    assert sigmat.qb2 == b'\xf8\x00\x05'
+
+    # Test signatures
     sig = (b"\x99\xd2<9$$0\x9fk\xfb\x18\xa0\x8c@r\x122.k\xb2\xc7\x1fp\x0e'm\x8f@"
            b'\xaa\xa5\x8c\xc8n\x85\xc8!\xf6q\x91p\xa9\xec\xcf\x92\xaf)\xde\xca'
            b'\xfc\x7f~\xd7o|\x17\x82\x1d\xd4<o"\x81&\t')


### PR DESCRIPTION
After writing code to support generation and verification of Inception, Rotation, and Interaction events and also the
serialization and deserialization of event streams with attached signatures, realized that the idxs field was a problem.

1) the use case for peer did where a set of peer act as mutually witnesses in a multi-sig scheme would have each peer generate a partial set of signatures. In this case idxs must be empty. However if idxs is empty and the event stream protocol is not framed than there is no way to identifier how many attached signatures.

To fix this added an new Signature Material special case derivation code for a special class where the derivation code includes the number or count of attached signatures. This replaces the most common use case for the idxs field which is to provide the count of attached signatures. This count code is inserted after the event and before the set of attached signatures.  

2. Given 1 then the only remaining use case for idxs is that one wants to require a given set of signatures. After some more thought realized that this is problem when done in a per event idxs field which includes per interaction event. We then have effectively interaction events defining what set of signatures to require to validate the interaction event. This is further constraint but just feels wrong to allow it this way. May cause some complications down the road. The best way to require a specific set of signatures is in the sith field but using the list format of weighted threshold. This is changed on each rotation event and is more in the spirit of KERI where control validation is established only in establishment events.

