### PR TITLE
Autonomic ID derivation support.

### DIFF
--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -1036,7 +1036,7 @@ class Aider(CryMat):
         if not (seed or secret):
             raise DerivationError("Missing seed or secret.")
 
-        signer = Signer(raw=seed, qb2=secret)
+        signer = Signer(raw=seed, qb64=secret)
 
         if verfer.raw != signer.verfer.raw:
             raise DerivationError("Key in ked not match seed.")

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -232,7 +232,7 @@ class CryMat:
 
     """
 
-    def __init__(self, raw=b'', qb64='', qb2='', code=CryOneDex.Ed25519N):
+    def __init__(self, raw=None, qb64=None, qb2=None, code=CryOneDex.Ed25519N):
         """
         Validate as fully qualified
         Parameters:
@@ -246,7 +246,7 @@ class CryMat:
         Else when qb64 or qb2 provided extract and assign .raw and .code
 
         """
-        if raw:  #  raw provided so infil with code
+        if raw is not None:  #  raw provided so infil with code
             if not isinstance(raw, (bytes, bytearray)):
                 raise TypeError("Not a bytes or bytearray, raw={}.".format(raw))
             pad = self._pad(raw)
@@ -266,12 +266,12 @@ class CryMat:
             self._code = code
             self._raw = bytes(raw)  # crypto ops require bytes not bytearray
 
-        elif qb64:
+        elif qb64 is not None:
             if hasattr(qb64, "decode"):  # converts bytes like to str
                 qb64 = qb64.decode("utf-8")
             self._exfil(qb64)
 
-        elif qb2:  # rewrite to use direct binary exfiltration
+        elif qb2 is not None:  # rewrite to use direct binary exfiltration
             self._exfil(encodeB64(qb2).decode("utf-8"))
 
         else:
@@ -522,7 +522,7 @@ class Signer(CryMat):
         sign: create signature
 
     """
-    def __init__(self,raw=b'', code=CryOneDex.Ed25519_Seed, transferable=True, **kwa):
+    def __init__(self,raw=None, code=CryOneDex.Ed25519_Seed, transferable=True, **kwa):
         """
         Assign signing cipher suite function to ._sign
 
@@ -667,7 +667,7 @@ class Diger(CryMat):
         verify: verifies signature
 
     """
-    def __init__(self, raw=b'', ser=b'', code=CryOneDex.Blake3_256, **kwa):
+    def __init__(self, raw=None, ser=None, code=CryOneDex.Blake3_256, **kwa):
         """
         Assign digest verification function to ._verify
 
@@ -735,7 +735,7 @@ class Nexter(Diger):
 
 
     """
-    def __init__(self, ser=b'', sith=None, keys=None, ked=None, **kwa):
+    def __init__(self, ser=None, sith=None, keys=None, ked=None, **kwa):
         """
         Assign digest verification function to ._verify
 
@@ -862,10 +862,16 @@ class Aider(CryMat):
     # elements in digest or signature derivation from delegated inception dip
     DipLabels = ["sith", "keys", "nxt", "toad", "wits", "perm", "seal"]
 
-    def __init__(self, raw=b'', code=CryOneDex.Ed25519N, ked=None, **kwa):
+    def __init__(self, raw=None, code=CryOneDex.Ed25519N, ked=None,
+                 seed=None, secret=None, **kwa):
         """
         assign ._derive to derive derivatin of aid from ked
         assign ._verify to verify derivation of aid from ked
+
+        Parameters:
+            seed is bytes seed when signature derivation
+            secret is qb64 when signature derivation when applicable
+               one of seed or secret must be provided when signature derivation
 
         """
         try:
@@ -880,10 +886,13 @@ class Aider(CryMat):
                 self._derive = self._DeriveBasicEd25519
             elif code == CryOneDex.Blake3_256:
                 self._derive = self._DeriveDigBlake3_256
+            elif code == CryTwoDex.Ed25519:
+                self._derive = self._DeriveSigEd25519
             else:
                 raise ValueError("Unsupported code = {} for aider.".format(code))
 
-            raw, code = self._derive(ked)  # use ked to derive aid
+            # use ked to derive aid
+            raw, code = self._derive(ked=ked, seed=seed, secret=secret)
             super(Aider, self).__init__(raw=raw, code=code, **kwa)
 
         if self.code == CryOneDex.Ed25519N:
@@ -892,6 +901,8 @@ class Aider(CryMat):
             self._verify = self._VerifyBasicEd25519
         elif self.code == CryOneDex.Blake3_256:
             self._verify = self._VerifyDigBlake3_256
+        elif code == CryTwoDex.Ed25519:
+            self._verify = self._VerifySigEd25519
         else:
             raise ValueError("Unsupported code = {} for aider.".format(self.code))
 
@@ -902,18 +913,19 @@ class Aider(CryMat):
                                                                #ked))
 
 
-    def derive(self, ked):
+    def derive(self, ked, seed=None, secret=None):
         """
         Returns tuple (raw, code) of aid as derived from key event dict ked.
                 uses a derivation code specific _derive method
 
         Parameters:
             ked is inception key event dict
+            seed is only used for sig derivation it is the secret key/secret
         """
-        return (self._derive(ked=ked))
+        return (self._derive(ked=ked, seed=seed, secret=secret))
 
 
-    def _DeriveBasicEd25519N(self, ked):
+    def _DeriveBasicEd25519N(self, ked, seed=None, secret=None):
         """
         Returns tuple (raw, code) of basic nontransferable Ed25519 aid (qb64)
             as derived from key event dict ked
@@ -943,7 +955,7 @@ class Aider(CryMat):
         return (verfer.raw, verfer.code)
 
 
-    def _DeriveBasicEd25519(self, ked):
+    def _DeriveBasicEd25519(self, ked, seed=None, secret=None):
         """
         Returns tuple (raw, code) of basic Ed25519 aid (qb64)
             as derived from key event dict ked
@@ -965,7 +977,7 @@ class Aider(CryMat):
         return (verfer.raw, verfer.code)
 
 
-    def _DeriveDigBlake3_256(self, ked):
+    def _DeriveDigBlake3_256(self, ked, seed=None, secret=None):
         """
         Returns tuple (raw, code) of basic Ed25519 aid (qb64)
             as derived from key event dict ked
@@ -984,9 +996,10 @@ class Aider(CryMat):
 
         values = extractValues(ked=ked, labels=labels)
         ser = "".join(values).encode("utf-8")
-        return (blake3.blake3(ser).digest(), CryOneDex.Blake3_256)
+        dig =  blake3.blake3(ser).digest()
+        return (dig, CryOneDex.Blake3_256)
 
-    def _DeriveSigEd25519(self, ked):
+    def _DeriveSigEd25519(self, ked, seed=None, secret=None):
         """
         Returns tuple (raw, code) of basic Ed25519 aid (qb64)
             as derived from key event dict ked
@@ -1005,7 +1018,34 @@ class Aider(CryMat):
 
         values = extractValues(ked=ked, labels=labels)
         ser = "".join(values).encode("utf-8")
-        return (blake3.blake3(ser).digest(), CryOneDex.Blake3_256)
+
+        try:
+            keys = ked["keys"]
+            if len(keys) != 1:
+                raise DerivationError("Basic derivation needs at most 1 key "
+                                      " got {} keys instead".format(len(keys)))
+            verfer = Verfer(qb64=keys[0])
+        except Exception as ex:
+            raise DerivationError("Error extracting public key ="
+                                  " = {}".format(ex))
+
+        if verfer.code not in [CryOneDex.Ed25519]:
+            raise DerivationError("Invalid derivation code = {}"
+                                  "".format(verfer.code))
+
+        if not (seed or secret):
+            raise DerivationError("Missing seed or secret.")
+
+        signer = Signer(raw=seed, qb2=secret)
+
+        if verfer.raw != signer.verfer.raw:
+            raise DerivationError("Key in ked not match seed.")
+
+        sigver = signer.sign(ser=ser)
+
+        # sig = pysodium.crypto_sign_detached(ser, signer.raw + verfer.raw)
+
+        return (sigver.raw, CryTwoDex.Ed25519)
 
 
     def verify(self, ked):
@@ -1014,7 +1054,7 @@ class Aider(CryMat):
                 False otherwise
 
         Parameters:
-            iked is inception key event dict
+            ked is inception key event dict
         """
         return (self._verify(ked=ked, aid=self.qb64))
 
@@ -1052,7 +1092,7 @@ class Aider(CryMat):
         inception key event dict (ked)
 
         Parameters:
-            iked is inception key event dict
+            ked is inception key event dict
             aid is Base64 fully qualified
         """
         try:
@@ -1075,7 +1115,7 @@ class Aider(CryMat):
         inception key event dict (ked)
 
         Parameters:
-            iked is inception key event dict
+            ked is inception key event dict
             aid is Base64 fully qualified
         """
         try:
@@ -1088,6 +1128,64 @@ class Aider(CryMat):
             return False
 
         return True
+
+
+    def _VerifySigEd25519(self, ked, aid):
+        """
+        Returns True if verified raises exception otherwise
+        Verify derivation of fully qualified Base64 aid from
+        inception key event dict (ked)
+
+        Parameters:
+            ked is inception key event dict
+            aid is Base64 fully qualified
+        """
+        try:
+            ilk = ked["ilk"]
+            if ilk == Ilks.icp:
+                labels = self.IcpLabels  # ICP_DERIVE_LABELS
+            elif ilk == Ilks.dip:
+                labels = self.DipLabels  # DIP_DERIVE_LABELS
+            else:
+                raise DerivationError("Invalid ilk = {} to derive aid.".format(ilk))
+
+            for l in labels:
+                if l not in ked:
+                    raise DerivationError("Missing element = {} from ked.".format(l))
+
+            values = extractValues(ked=ked, labels=labels)
+            ser = "".join(values).encode("utf-8")
+
+            try:
+                keys = ked["keys"]
+                if len(keys) != 1:
+                    raise DerivationError("Basic derivation needs at most 1 key "
+                                          " got {} keys instead".format(len(keys)))
+                verfer = Verfer(qb64=keys[0])
+            except Exception as ex:
+                raise DerivationError("Error extracting public key ="
+                                      " = {}".format(ex))
+
+            if verfer.code not in [CryOneDex.Ed25519]:
+                raise DerivationError("Invalid derivation code = {}"
+                                      "".format(verfer.code))
+
+            sigver = Sigver(qb64=aid, verfer=verfer)
+
+            result = sigver.verfer.verify(sig=sigver.raw, ser=ser)
+            return result
+
+            #try:  # verify returns None if valid else raises ValueError
+                #result = pysodium.crypto_sign_verify_detached(sig, ser, verfer.raw)
+            #except Exception as ex:
+                #return False
+
+        except Exception as ex:
+            return False
+
+        return True
+
+
 
 
 

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -971,7 +971,7 @@ class Aider(CryMat):
         if ilk == Ilks.icp:
             labels = ICP_DERIVE_LABELS
         elif ilk == Ilks.dip:
-            labels == DIP_DERIVE_LABELS
+            labels = DIP_DERIVE_LABELS
         else:
             raise DerivationError("Invalid ilk = {} to derive aid.".format(ilk))
 
@@ -1061,7 +1061,7 @@ class Aider(CryMat):
             if ilk == Ilks.icp:
                 labels = ICP_DERIVE_LABELS
             elif ilk == Ilks.dip:
-                labels == DIP_DERIVE_LABELS
+                labels = DIP_DERIVE_LABELS
             else:
                 raise DerivationError("Invalid ilk = {} to derive aid.".format(ilk))
 

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -857,6 +857,10 @@ class Aider(CryMat):
         verify():  Verifies derivation of aid
 
     """
+    # elements in digest or signature derivation from inception icp
+    IcpLabels = ["sith", "keys", "nxt", "toad", "wits", "cnfg"]
+    # elements in digest or signature derivation from delegated inception dip
+    DipLabels = ["sith", "keys", "nxt", "toad", "wits", "perm", "seal"]
 
     def __init__(self, raw=b'', code=CryOneDex.Ed25519N, ked=None, **kwa):
         """
@@ -909,8 +913,7 @@ class Aider(CryMat):
         return (self._derive(ked=ked))
 
 
-    @staticmethod
-    def _ed25519nDerive(ked):
+    def _ed25519nDerive(self, ked):
         """
         Returns tuple (raw, code) of basic nontransferable Ed25519 aid (qb64)
             as derived from key event dict ked
@@ -939,8 +942,8 @@ class Aider(CryMat):
 
         return (verfer.raw, verfer.code)
 
-    @staticmethod
-    def _ed25519Derive(ked):
+
+    def _ed25519Derive(self, ked):
         """
         Returns tuple (raw, code) of basic Ed25519 aid (qb64)
             as derived from key event dict ked
@@ -961,17 +964,17 @@ class Aider(CryMat):
 
         return (verfer.raw, verfer.code)
 
-    @staticmethod
-    def _blake3_256Derive(ked):
+
+    def _blake3_256Derive(self, ked):
         """
         Returns tuple (raw, code) of basic Ed25519 aid (qb64)
             as derived from key event dict ked
         """
         ilk = ked["ilk"]
         if ilk == Ilks.icp:
-            labels = ICP_DERIVE_LABELS
+            labels = self.IcpLabels  # ICP_DERIVE_LABELS
         elif ilk == Ilks.dip:
-            labels = DIP_DERIVE_LABELS
+            labels = self.DipLabels  # DIP_DERIVE_LABELS
         else:
             raise DerivationError("Invalid ilk = {} to derive aid.".format(ilk))
 
@@ -995,8 +998,7 @@ class Aider(CryMat):
         return (self._verify(ked=ked, aid=self.qb64))
 
 
-    @staticmethod
-    def _ed25519nVerify(ked, aid):
+    def _ed25519nVerify(self, ked, aid):
         """
         Returns True if verified raises exception otherwise
         Verify derivation of fully qualified Base64 aid from inception iked dict
@@ -1022,8 +1024,7 @@ class Aider(CryMat):
         return True
 
 
-    @staticmethod
-    def _ed25519Verify(ked, aid):
+    def _ed25519Verify(self, ked, aid):
         """
         Returns True if verified raises exception otherwise
         Verify derivation of fully qualified Base64 aid from
@@ -1045,8 +1046,8 @@ class Aider(CryMat):
 
         return True
 
-    @staticmethod
-    def _blake3_256Verify(ked, aid):
+
+    def _blake3_256Verify(self, ked, aid):
         """
         Returns True if verified raises exception otherwise
         Verify derivation of fully qualified Base64 aid from
@@ -1057,21 +1058,7 @@ class Aider(CryMat):
             aid is Base64 fully qualified
         """
         try:
-            ilk = ked["ilk"]
-            if ilk == Ilks.icp:
-                labels = ICP_DERIVE_LABELS
-            elif ilk == Ilks.dip:
-                labels = DIP_DERIVE_LABELS
-            else:
-                raise DerivationError("Invalid ilk = {} to derive aid.".format(ilk))
-
-            for l in labels:
-                if l not in ked:
-                    raise DerivationError("Missing element = {} from ked.".format(l))
-
-            values = extractValues(ked=ked, labels=labels)
-            ser = "".join(values).encode("utf-8")
-            raw = blake3.blake3(ser).digest()
+            raw, code =  self._blake3_256Derive(ked=ked)
             crymat = CryMat(raw=raw, code=CryOneDex.Blake3_256)
             if crymat.qb64 != aid:
                 return False
@@ -1080,6 +1067,7 @@ class Aider(CryMat):
             return False
 
         return True
+
 
 
 BASE64_PAD = '='

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -86,7 +86,9 @@ PDELs = dict()
 DELs = dict()
 
 
-def incept( keys,
+def incept(
+            keys,
+            code=None,
             version=Version,
             kind=Serials.json,
             sith=None,
@@ -154,8 +156,12 @@ def incept( keys,
                cnfg=cnfg,  # list of config ordered mappings may be empty
                )
 
-    # raises derivation error if non-empty nxt but ephemeral code
-    aider = Aider(ked=ked)  # Derive AID from ked
+    if code is None and len(keys) == 1:
+        aider = Aider(qb64=keys[0])
+    else:
+        # raises derivation error if non-empty nxt but ephemeral code
+        aider = Aider(ked=ked, code=code)  # Derive AID from ked and code
+
     ked["aid"] = aider.qb64  # update aid element in ked with aid qb64
 
     return Serder(ked=ked)  # return serialized ked

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -28,6 +28,16 @@ from .coring import Versify, Serials, Ilks, CryOneDex
 from .coring import Signer, Verfer, Diger, Nexter, Aider, Serder
 from .coring import SigCounter, Siger
 
+ICP_LABELS = ["vs", "aid", "sn", "ilk", "sith", "keys", "nxt",
+              "toad", "wits", "cnfg"]
+ROT_LABELS = ["vs", "aid", "sn", "ilk", "dig", "sith", "keys", "nxt",
+              "toad", "cuts", "adds", "data"]
+IXN_LABELS = ["vs", "aid", "sn", "ilk", "dig", "data"]
+DIP_LABELS = ["vs", "aid", "sn", "ilk", "sith", "keys", "nxt",
+              "toad", "wits", "perm", "seal"]
+DRT_LABELS = ["vs", "aid", "sn", "ilk", "dig", "sith", "keys", "nxt",
+              "toad", "cuts", "adds", "perm", "seal"]
+
 
 @dataclass(frozen=True)
 class TraitCodex:
@@ -364,6 +374,18 @@ class Kever:
             siger.verfer = self.verfers[siger.index]  # assign verfer
 
         ked = serder.ked
+
+        for k in ICP_LABELS:
+            if k not in ked:
+                raise ValidationError("Missing element = {} from {}  event."
+                                      "".format(k, Ilks.icp))
+
+        ilk = ked["ilk"]
+        if ilk != Ilks.icp:
+            raise ValidationError("Expected ilk = {} got {}."
+                                              "".format(Ilks.icp, ilk))
+        self.ilk = ilk
+
         sith = ked["sith"]
         if isinstance(sith, str):
             self.sith = int(sith, 16)
@@ -390,11 +412,7 @@ class Kever:
                                               "".format(self.sn, ked))
         self.diger = serder.diger
 
-        ilk = ked["ilk"]
-        if ilk != Ilks.icp:
-            raise ValidationError("Expected ilk = {} got {}."
-                                              "".format(Ilks.icp, ilk))
-        self.ilk = ilk
+
 
         nxt = ked["nxt"]
         self.nexter = Nexter(qb64=nxt) if nxt else None
@@ -465,6 +483,12 @@ class Kever:
                                   " = {}.".format(aid, self.aider.qb64))
 
         if ilk == Ilks.rot:  # subsequent rotation event
+            for k in ROT_LABELS:
+                if k not in ked:
+                    raise ValidationError("Missing element = {} from {}  event."
+                                          "".format(k, Ilks.rot))
+
+
             if sn > self.sn + 1:  #  out of order event
                 raise ValidationError("Out of order event sn = {} expecting"
                                       " = {}.".format(sn, self.sn+1))
@@ -599,6 +623,11 @@ class Kever:
             if self.estOnly:
                 raise ValidationError("Unexpected non-establishment event = {}."
                                   "".format(serder))
+
+            for k in IXN_LABELS:
+                if k not in ked:
+                    raise ValidationError("Missing element = {} from {} event."
+                                          "".format(k, Ilks.ixn))
 
             if not sn == (self.sn + 1):  # sn not in order
                 raise ValidationError("Invalid sn = {} expecting = {}.".format(sn, self.sn+1))

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -133,7 +133,7 @@ def incept( keys,
     cnfg = cnfg if cnfg is not None else []
 
     ked = dict(vs=vs,  # version string
-               aid="",  # ab64 prefix
+               aid="",  # qb64 prefix
                sn="{:x}".format(sn),  # hex string no leading zeros lowercase
                ilk=ilk,
                sith="{:x}".format(sith), # hex string no leading zeros lowercase

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -669,6 +669,45 @@ def test_aider():
     assert aider.qb64 == 'EQrpcQ1RX0jDKcBbGXWZra3dr3bFyz6Ly1icEBlgD20s'
     assert aider.verify(ked=ked) == True
 
+    #  Test signature derivation
+
+    seed = pysodium.randombytes(pysodium.crypto_sign_SEEDBYTES)
+    seed =  (b'\xdf\x95\xf9\xbcK@s="\xee\x95w\xbf>F&\xbb\x82\x8f)\x95\xb9\xc0\x1eS\x1b{L'
+             b't\xcfH\xa6')
+    signer = Signer(raw=seed)
+    secret = signer.qb64
+    assert secret ==  'A35X5vEtAcz0i7pV3vz5GJruCjymVucAeUxt7THTPSKY'
+
+    vs = Versify(version=Version, kind=Serials.json, size=0)
+    sn = 0
+    ilk = Ilks.icp
+    sith = 1
+    keys = [signer.verfer.qb64]
+    nxt = ""
+    toad = 0
+    wits = []
+    cnfg = []
+
+    nexter = Nexter(sith=1, keys=[nxtfer.qb64])
+    ked = dict(vs=vs,  # version string
+               aid="",  # qb64 prefix
+               sn="{:x}".format(sn),  # hex string no leading zeros lowercase
+               ilk=ilk,
+               sith="{:x}".format(sith), # hex string no leading zeros lowercase
+               keys=keys,  # list of qb64
+               nxt=nexter.qb64,  # hash qual Base64
+               toad="{:x}".format(toad),  # hex string no leading zeros lowercase
+               wits=wits,  # list of qb64 may be empty
+               cnfg=cnfg,  # list of config ordered mappings may be empty
+               )
+
+    aider = Aider(ked=ked, code=CryTwoDex.Ed25519, seed=seed)
+    assert aider.qb64 == '0BSb9qBNXUerVs4IDYnai29AXcPQJtudLPfzfvehicA7LrswWBPmNlNQK9gIJB4pny2YpuB3m6-pgyl4cU65RRCA'
+    assert aider.verify(ked=ked) == True
+
+    #aider = Aider(ked=ked, code=CryTwoDex.Ed25519, secret=secret)
+    #assert aider.qb64 == '0BSb9qBNXUerVs4IDYnai29AXcPQJtudLPfzfvehicA7LrswWBPmNlNQK9gIJB4pny2YpuB3m6-pgyl4cU65RRCA'
+    #assert aider.verify(ked=ked) == True
 
     """ Done Test """
 

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -646,6 +646,29 @@ def test_aider():
     assert aider.qb64 == 'EXpGDy9FxDESc974WW86xDxM0fQgKjhDWOklCXtstkus'
     assert aider.verify(ked=ked) == True
 
+    perm = []
+    seal = dict(aid = 'EXpGDy9FxDESc974WW86xDxM0fQgKjhDWOklCXtstkus',
+                sn  = '2',
+                ilk = Ilks.ixn,
+                dig = 'E03rxRmMcP2-I2Gd0sUhlYwjk8KEz5gNGxPwPg-sGJds')
+
+    ked = dict(vs=vs,  # version string
+               aid="",  # qb64 prefix
+               sn="{:x}".format(sn),  # hex string no leading zeros lowercase
+               ilk=Ilks.dip,
+               sith="{:x}".format(sith), # hex string no leading zeros lowercase
+               keys=keys,  # list of qb64
+               nxt=nexter.qb64,  # hash qual Base64
+               toad="{:x}".format(toad),  # hex string no leading zeros lowercase
+               wits=wits,  # list of qb64 may be empty
+               perm=cnfg,  # list of config ordered mappings may be empty
+               seal=seal
+               )
+
+    aider = Aider(ked=ked, code=CryOneDex.Blake3_256)
+    assert aider.qb64 == 'EQrpcQ1RX0jDKcBbGXWZra3dr3bFyz6Ly1icEBlgD20s'
+    assert aider.verify(ked=ked) == True
+
 
     """ Done Test """
 

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -705,9 +705,9 @@ def test_aider():
     assert aider.qb64 == '0BSb9qBNXUerVs4IDYnai29AXcPQJtudLPfzfvehicA7LrswWBPmNlNQK9gIJB4pny2YpuB3m6-pgyl4cU65RRCA'
     assert aider.verify(ked=ked) == True
 
-    #aider = Aider(ked=ked, code=CryTwoDex.Ed25519, secret=secret)
-    #assert aider.qb64 == '0BSb9qBNXUerVs4IDYnai29AXcPQJtudLPfzfvehicA7LrswWBPmNlNQK9gIJB4pny2YpuB3m6-pgyl4cU65RRCA'
-    #assert aider.verify(ked=ked) == True
+    aider = Aider(ked=ked, code=CryTwoDex.Ed25519, secret=secret)
+    assert aider.qb64 == '0BSb9qBNXUerVs4IDYnai29AXcPQJtudLPfzfvehicA7LrswWBPmNlNQK9gIJB4pny2YpuB3m6-pgyl4cU65RRCA'
+    assert aider.verify(ked=ked) == True
 
     """ Done Test """
 

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -20,7 +20,8 @@ from keri.kering import ValidationError, EmptyMaterialError, DerivationError
 from keri.core.coring import CrySelDex, CryOneDex, CryTwoDex, CryFourDex
 from keri.core.coring import CryOneSizes, CryOneRawSizes, CryTwoSizes, CryTwoRawSizes
 from keri.core.coring import CryFourSizes, CryFourRawSizes, CrySizes, CryRawSizes
-from keri.core.coring import CryMat, Verfer, Sigver, Signer, Diger, Nexter, Aider
+from keri.core.coring import CryMat, Verfer, Sigver, Signer, Diger, Nexter
+from keri.core.coring import Aider
 from keri.core.coring import generateSigners,  generateSecrets
 from keri.core.coring import SigSelDex
 from keri.core.coring import SigCntDex, SigCntSizes, SigCntRawSizes
@@ -532,18 +533,31 @@ def test_nexter():
     """ Done Test """
 
 
+
 def test_aider():
     """
     Test the support functionality for aider subclass of crymat
     """
+
+    # verkey,  sigkey = pysodium.crypto_sign_keypair()
+    verkey = (b'\xacr\xda\xc83~\x99r\xaf\xeb`\xc0\x8cR\xd7\xd7\xf69\xc8E\x1e\xd2\xf0='
+              b'`\xf7\xbf\x8a\x18\x8a`q')
+    verfer = Verfer(raw=verkey )
+    assert verfer.qb64 == 'BrHLayDN-mXKv62DAjFLX1_Y5yEUe0vA9YPe_ihiKYHE'
+
+    nxtkey = (b"\xa6_\x894J\xf25T\xc1\x83#\x06\x98L\xa6\xef\x1a\xb3h\xeaA:x'\xda\x04\x88\xb2"
+              b'\xc4_\xf6\x00')
+    nxtfer = Verfer(raw=nxtkey, code=CryOneDex.Ed25519)
+    assert nxtfer.qb64 == 'Dpl-JNEryNVTBgyMGmEym7xqzaOpBOngn2gSIssRf9gA'
+
     with pytest.raises(EmptyMaterialError):
         aider = Aider()
 
-    verkey,  sigkey = pysodium.crypto_sign_keypair()
-
     with pytest.raises(ValueError):
-        aider = Aider(raw=verkey, code=CryOneDex.Blake3_256)
+        aider = Aider(raw=verkey, code=CryOneDex.SHA2_256)
 
+
+    # test creation given raw and code no derivation
     aider = Aider(raw=verkey)  # defaults provide Ed25519N aider
     assert aider.code == CryOneDex.Ed25519N
     assert len(aider.raw) == CryOneRawSizes[aider.code]
@@ -568,11 +582,14 @@ def test_aider():
     assert aider.code == CryOneDex.Ed25519N
     assert aider.verify(ked=ked) == False
 
-    # derive from ked
+    # Test basic derivation from ked
     ked = dict(keys=[verfer.qb64], nxt="")
-    aider = Aider(ked=ked)
+    aider = Aider(ked=ked, code=CryOneDex.Ed25519)
     assert aider.qb64 == verfer.qb64
     assert aider.verify(ked=ked) == True
+
+    with pytest.raises(DerivationError):
+        aider = Aider(ked=ked)
 
     verfer = Verfer(raw=verkey, code=CryOneDex.Ed25519N)
     ked = dict(keys=[verfer.qb64], nxt="")
@@ -583,6 +600,53 @@ def test_aider():
     ked = dict(keys=[verfer.qb64], nxt="ABCD")
     with pytest.raises(DerivationError):
         aider = Aider(ked=ked)
+
+    # Test digest derivation from inception ked
+    vs = Versify(version=Version, kind=Serials.json, size=0)
+    sn = 0
+    ilk = Ilks.icp
+    sith = 1
+    keys = [Aider(raw=verkey, code=CryOneDex.Ed25519).qb64]
+    nxt = ""
+    toad = 0
+    wits = []
+    cnfg = []
+
+    ked = dict(vs=vs,  # version string
+               aid="",  # qb64 prefix
+               sn="{:x}".format(sn),  # hex string no leading zeros lowercase
+               ilk=ilk,
+               sith="{:x}".format(sith), # hex string no leading zeros lowercase
+               keys=keys,  # list of qb64
+               nxt=nxt,  # hash qual Base64
+               toad="{:x}".format(toad),  # hex string no leading zeros lowercase
+               wits=wits,  # list of qb64 may be empty
+               cnfg=cnfg,  # list of config ordered mappings may be empty
+               )
+
+    aider = Aider(ked=ked, code=CryOneDex.Blake3_256)
+    assert aider.qb64 == 'E03rxRmMcP2-I2Gd0sUhlYwjk8KEz5gNGxPwPg-sGJds'
+    assert aider.verify(ked=ked) == True
+
+
+    nexter = Nexter(sith=1, keys=[nxtfer.qb64])
+    ked = dict(vs=vs,  # version string
+               aid="",  # qb64 prefix
+               sn="{:x}".format(sn),  # hex string no leading zeros lowercase
+               ilk=ilk,
+               sith="{:x}".format(sith), # hex string no leading zeros lowercase
+               keys=keys,  # list of qb64
+               nxt=nexter.qb64,  # hash qual Base64
+               toad="{:x}".format(toad),  # hex string no leading zeros lowercase
+               wits=wits,  # list of qb64 may be empty
+               cnfg=cnfg,  # list of config ordered mappings may be empty
+               )
+
+    aider = Aider(ked=ked, code=CryOneDex.Blake3_256)
+    assert aider.qb64 == 'EXpGDy9FxDESc974WW86xDxM0fQgKjhDWOklCXtstkus'
+    assert aider.verify(ked=ked) == True
+
+
     """ Done Test """
 
 
@@ -1164,4 +1228,4 @@ def test_serder():
 
 
 if __name__ == "__main__":
-    test_sigcounter()
+    test_aider()

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -74,7 +74,8 @@ def test_keyeventfuncs():
 
 
     with pytest.raises(DerivationError):
-        serder = incept(keys=keys0, nxt="ABCDE")  # non-empty nxt wtih non-transferable code
+        # non-empty nxt wtih non-transferable code
+        serder = incept(keys=keys0, code=CryOneDex.Ed25519N, nxt="ABCDE")
 
     # Inception: Transferable Case but abandoned in incept so equivalent
     signer0 = Signer(raw=seed)  #  original signing keypair transferable default
@@ -197,8 +198,9 @@ def test_kever():
 
 
     # Derive AID from ked
-    aid0 = Aider(ked=ked0)
+    aid0 = Aider(ked=ked0, code = CryOneDex.Ed25519)
     assert aid0.code == CryOneDex.Ed25519
+    assert aid0.qb64 == skp0.verfer.qb64
 
     # update ked with aid
     ked0["aid"] = aid0.qb64
@@ -914,8 +916,9 @@ def test_process_transferable():
 
 
     # Derive AID from ked
-    aid0 = Aider(ked=ked0)
+    aid0 = Aider(ked=ked0, code=CryOneDex.Ed25519)
     assert aid0.code == CryOneDex.Ed25519
+    assert aid0.qb64 == skp0.verfer.qb64
 
     # update ked with aid
     ked0["aid"] = aid0.qb64
@@ -1092,4 +1095,4 @@ def test_process_manual():
 
 
 if __name__ == "__main__":
-    test_kevery()
+    test_keyeventfuncs()

--- a/tests/help/test_helping.py
+++ b/tests/help/test_helping.py
@@ -81,12 +81,11 @@ def test_extractvalues():
                cnfg=[dict(trait="EstOnly")],
                )
 
-    labels = ["vs", "sn", "ilk", "sith", "keys", "nxt", "toad", "wits", "cnfg"]
+    labels = ["vs", "ilk", "sith", "keys", "nxt", "toad", "wits", "cnfg"]
 
     values = extractValues(ked=ked, labels=labels)
 
     assert values == [  'KERI10JSON0000fb_',
-                        '0',
                         'icp',
                         '1',
                         'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA',
@@ -98,7 +97,7 @@ def test_extractvalues():
 
     ser = "".join(values)
 
-    assert ser == ('KERI10JSON0000fb_0icp1DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtW'
+    assert ser == ('KERI10JSON0000fb_icp1DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtW'
                    'TOunRAEGAPkzNZMtX-QiVgbRbyAIZGoXvbGv9IPb0foWTZvI_40EstOnly')
     """End Test"""
 

--- a/tests/help/test_helping.py
+++ b/tests/help/test_helping.py
@@ -9,6 +9,7 @@ import pysodium
 
 
 from keri.help.helping import mdict
+from keri.help.helping import extractValues
 
 
 def test_mdict():
@@ -57,6 +58,50 @@ def test_mdict():
 
     """End Test"""
 
+def test_extractvalues():
+    """
+    Test function extractValues
+    """
+    (b'{"vs":"KERI10JSON0000fb_","aid":"DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_'
+                                b'ZOoeKtWTOunRA","sn":"0","ilk":"icp","sith":"1","keys":["DSuhyBcP'
+                                b'ZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"nxt":"EGAPkzNZMtX-QiVgbR'
+                                b'byAIZGoXvbGv9IPb0foWTZvI_4","toad":"0","wits":[],"cnfg":[]}-AABA'
+                                b'A8yMYsLXbmnwXWIsdZ7Uzw3Q7ppynI1xYCf-43hsf7XIgp5NZ-HlZbDC3o0lwWEF'
+                                b'nk4O6glvxx3bJ8Zfgg606DA')
+
+    ked = dict(vs="KERI10JSON0000fb_",
+               aid="DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA",
+               sn="0",
+               ilk="icp",
+               sith="1",
+               keys=["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],
+               nxt="EGAPkzNZMtX-QiVgbRbyAIZGoXvbGv9IPb0foWTZvI_4",
+               toad="0",
+               wits=[],  # list of qb64 may be empty
+               cnfg=[dict(trait="EstOnly")],
+               )
+
+    labels = ["vs", "sn", "ilk", "sith", "keys", "nxt", "toad", "wits", "cnfg"]
+
+    values = extractValues(ked=ked, labels=labels)
+
+    assert values == [  'KERI10JSON0000fb_',
+                        '0',
+                        'icp',
+                        '1',
+                        'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA',
+                        'EGAPkzNZMtX-QiVgbRbyAIZGoXvbGv9IPb0foWTZvI_4',
+                        '0',
+                        'EstOnly'
+                    ]
+
+
+    ser = "".join(values)
+
+    assert ser == ('KERI10JSON0000fb_0icp1DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtW'
+                   'TOunRAEGAPkzNZMtX-QiVgbRbyAIZGoXvbGv9IPb0foWTZvI_40EstOnly')
+    """End Test"""
+
 def test_conversions():
     """
     Test conversion helpers
@@ -66,4 +111,4 @@ def test_conversions():
 
 
 if __name__ == "__main__":
-    test_mdict()
+    test_extractvalues()


### PR DESCRIPTION
Added support for self-addressing self-certifying and also self-signing self-certifying autonomic identifier prefixes to be derived from inception  key event dict and code.  This includes both regular inception and delegated inception. So delegated self-certifying self-addressing identifiers now supported.

Only added support for Ed25519 and Blake3

Now have support for all the main self-certifying identifier types. See the core.coring.Aider class where this support is provided.  Also tests of Aider in test_coring.py test_aider 