### PR TITLE
Changed label "aid" to "pre"

### DIFF
--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -337,7 +337,7 @@ class CryMat:
         code = qb64[:pre]
 
         # need to map code to length so can only consume proper number of chars
-        #  from front of qb64 so can use with full identifiers not just aid prefixes
+        #  from front of qb64 so can use with full identifiers not just prefixes
 
         if code in CryOneDex:  # One Char code
             qb64 = qb64[:CryOneSizes[code]]  # strip of identifier after prefix
@@ -854,7 +854,7 @@ class Prefixer(CryMat):
     Properties:
 
     Methods:
-        verify():  Verifies derivation of aid
+        verify():  Verifies derivation of aid prefix
 
     """
     # elements in digest or signature derivation from inception icp
@@ -865,8 +865,8 @@ class Prefixer(CryMat):
     def __init__(self, raw=None, code=CryOneDex.Ed25519N, ked=None,
                  seed=None, secret=None, **kwa):
         """
-        assign ._derive to derive derivatin of aid from ked
-        assign ._verify to verify derivation of aid from ked
+        assign ._derive to derive derivatin of aid prefix from ked
+        assign ._verify to verify derivation of aid prefix  from ked
 
         Parameters:
             seed is bytes seed when signature derivation
@@ -891,7 +891,7 @@ class Prefixer(CryMat):
             else:
                 raise ValueError("Unsupported code = {} for prefixer.".format(code))
 
-            # use ked to derive aid
+            # use ked to derive aid prefix
             raw, code = self._derive(ked=ked, seed=seed, secret=secret)
             super(Prefixer, self).__init__(raw=raw, code=code, **kwa)
 
@@ -907,7 +907,7 @@ class Prefixer(CryMat):
             raise ValueError("Unsupported code = {} for prefixer.".format(self.code))
 
         #if ked and not self.verify(ked):
-            #raise DerivationError("Error verifying derived aid = {} with code "
+            #raise DerivationError("Error verifying derived prefix = {} with code "
                                   #"= {} from ked = {}.".format(self.qb64,
                                                                #self.code,
                                                                #ked))
@@ -915,7 +915,7 @@ class Prefixer(CryMat):
 
     def derive(self, ked, seed=None, secret=None):
         """
-        Returns tuple (raw, code) of aid as derived from key event dict ked.
+        Returns tuple (raw, code) of aid prefix as derived from key event dict ked.
                 uses a derivation code specific _derive method
 
         Parameters:
@@ -927,7 +927,7 @@ class Prefixer(CryMat):
 
     def _DeriveBasicEd25519N(self, ked, seed=None, secret=None):
         """
-        Returns tuple (raw, code) of basic nontransferable Ed25519 aid (qb64)
+        Returns tuple (raw, code) of basic nontransferable Ed25519 prefix (qb64)
             as derived from key event dict ked
         """
         try:
@@ -957,7 +957,7 @@ class Prefixer(CryMat):
 
     def _DeriveBasicEd25519(self, ked, seed=None, secret=None):
         """
-        Returns tuple (raw, code) of basic Ed25519 aid (qb64)
+        Returns tuple (raw, code) of basic Ed25519 prefix (qb64)
             as derived from key event dict ked
         """
         try:
@@ -979,7 +979,7 @@ class Prefixer(CryMat):
 
     def _DeriveDigBlake3_256(self, ked, seed=None, secret=None):
         """
-        Returns tuple (raw, code) of basic Ed25519 aid (qb64)
+        Returns tuple (raw, code) of basic Ed25519 pre (qb64)
             as derived from key event dict ked
         """
         ilk = ked["ilk"]
@@ -988,7 +988,7 @@ class Prefixer(CryMat):
         elif ilk == Ilks.dip:
             labels = self.DipLabels  # DIP_DERIVE_LABELS
         else:
-            raise DerivationError("Invalid ilk = {} to derive aid.".format(ilk))
+            raise DerivationError("Invalid ilk = {} to derive pre.".format(ilk))
 
         for l in labels:
             if l not in ked:
@@ -1001,7 +1001,7 @@ class Prefixer(CryMat):
 
     def _DeriveSigEd25519(self, ked, seed=None, secret=None):
         """
-        Returns tuple (raw, code) of basic Ed25519 aid (qb64)
+        Returns tuple (raw, code) of basic Ed25519 pre (qb64)
             as derived from key event dict ked
         """
         ilk = ked["ilk"]
@@ -1010,7 +1010,7 @@ class Prefixer(CryMat):
         elif ilk == Ilks.dip:
             labels = self.DipLabels  # DIP_DERIVE_LABELS
         else:
-            raise DerivationError("Invalid ilk = {} to derive aid.".format(ilk))
+            raise DerivationError("Invalid ilk = {} to derive pre.".format(ilk))
 
         for l in labels:
             if l not in ked:
@@ -1056,24 +1056,24 @@ class Prefixer(CryMat):
         Parameters:
             ked is inception key event dict
         """
-        return (self._verify(ked=ked, aid=self.qb64))
+        return (self._verify(ked=ked, pre=self.qb64))
 
 
-    def _VerifyBasicEd25519N(self, ked, aid):
+    def _VerifyBasicEd25519N(self, ked, pre):
         """
         Returns True if verified raises exception otherwise
-        Verify derivation of fully qualified Base64 aid from inception iked dict
+        Verify derivation of fully qualified Base64 pre from inception iked dict
 
         Parameters:
             ked is inception key event dict
-            aid is Base64 fully qualified
+            pre is Base64 fully qualified prefix
         """
         try:
             keys = ked["keys"]
             if len(keys) != 1:
                 return False
 
-            if keys[0] != aid:
+            if keys[0] != pre:
                 return False
 
             if ked["nxt"]:  # must be empty
@@ -1085,22 +1085,22 @@ class Prefixer(CryMat):
         return True
 
 
-    def _VerifyBasicEd25519(self, ked, aid):
+    def _VerifyBasicEd25519(self, ked, pre):
         """
         Returns True if verified raises exception otherwise
-        Verify derivation of fully qualified Base64 aid from
+        Verify derivation of fully qualified Base64 prefix from
         inception key event dict (ked)
 
         Parameters:
             ked is inception key event dict
-            aid is Base64 fully qualified
+            pre is Base64 fully qualified prefix
         """
         try:
             keys = ked["keys"]
             if len(keys) != 1:
                 return False
 
-            if keys[0] != aid:
+            if keys[0] != pre:
                 return False
         except Exception as ex:
             return False
@@ -1108,20 +1108,20 @@ class Prefixer(CryMat):
         return True
 
 
-    def _VerifyDigBlake3_256(self, ked, aid):
+    def _VerifyDigBlake3_256(self, ked, pre):
         """
         Returns True if verified raises exception otherwise
-        Verify derivation of fully qualified Base64 aid from
+        Verify derivation of fully qualified Base64 prefix from
         inception key event dict (ked)
 
         Parameters:
             ked is inception key event dict
-            aid is Base64 fully qualified
+            pre is Base64 fully qualified
         """
         try:
             raw, code =  self._DeriveDigBlake3_256(ked=ked)
             crymat = CryMat(raw=raw, code=CryOneDex.Blake3_256)
-            if crymat.qb64 != aid:
+            if crymat.qb64 != pre:
                 return False
 
         except Exception as ex:
@@ -1130,15 +1130,15 @@ class Prefixer(CryMat):
         return True
 
 
-    def _VerifySigEd25519(self, ked, aid):
+    def _VerifySigEd25519(self, ked, pre):
         """
         Returns True if verified raises exception otherwise
-        Verify derivation of fully qualified Base64 aid from
+        Verify derivation of fully qualified Base64 prefix from
         inception key event dict (ked)
 
         Parameters:
             ked is inception key event dict
-            aid is Base64 fully qualified
+            pre is Base64 fully qualified prefix
         """
         try:
             ilk = ked["ilk"]
@@ -1147,7 +1147,7 @@ class Prefixer(CryMat):
             elif ilk == Ilks.dip:
                 labels = self.DipLabels  # DIP_DERIVE_LABELS
             else:
-                raise DerivationError("Invalid ilk = {} to derive aid.".format(ilk))
+                raise DerivationError("Invalid ilk = {} to derive prefix.".format(ilk))
 
             for l in labels:
                 if l not in ked:
@@ -1170,7 +1170,7 @@ class Prefixer(CryMat):
                 raise DerivationError("Invalid derivation code = {}"
                                       "".format(verfer.code))
 
-            sigver = Sigver(qb64=aid, verfer=verfer)
+            sigver = Sigver(qb64=pre, verfer=verfer)
 
             result = sigver.verfer.verify(sig=sigver.raw, ser=ser)
             return result
@@ -1564,7 +1564,7 @@ class SigMat:
         index = 0
 
         # need to map code to length so can only consume proper number of chars
-        #  from front of qb64 so can use with full identifiers not just aid prefixes
+        # from front of qb64 so can use with full identifiers not just prefixes
 
         if code in SigTwoDex:  # 2 char = 1 code + 1 index
             qb64 = qb64[:SigTwoSizes[code]]  # strip of exact len identifier after prefix

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -842,7 +842,7 @@ ICP_DERIVE_LABELS = ["sith", "keys", "nxt", "toad", "wits", "cnfg"]
 DIP_DERIVE_LABELS = ["sith", "keys", "nxt", "toad", "wits", "perm", "seal"]
 
 
-class Aider(CryMat):
+class Prefixer(CryMat):
     """
     DigAider is CryMat subclass for autonomic identifier prefix using
     derivation as determined by code from ked
@@ -875,7 +875,7 @@ class Aider(CryMat):
 
         """
         try:
-            super(Aider, self).__init__(raw=raw, code=code, **kwa)
+            super(Prefixer, self).__init__(raw=raw, code=code, **kwa)
         except EmptyMaterialError as ex:
             if not ked or not code:
                 raise  ex
@@ -889,11 +889,11 @@ class Aider(CryMat):
             elif code == CryTwoDex.Ed25519:
                 self._derive = self._DeriveSigEd25519
             else:
-                raise ValueError("Unsupported code = {} for aider.".format(code))
+                raise ValueError("Unsupported code = {} for prefixer.".format(code))
 
             # use ked to derive aid
             raw, code = self._derive(ked=ked, seed=seed, secret=secret)
-            super(Aider, self).__init__(raw=raw, code=code, **kwa)
+            super(Prefixer, self).__init__(raw=raw, code=code, **kwa)
 
         if self.code == CryOneDex.Ed25519N:
             self._verify = self._VerifyBasicEd25519N
@@ -904,7 +904,7 @@ class Aider(CryMat):
         elif code == CryTwoDex.Ed25519:
             self._verify = self._VerifySigEd25519
         else:
-            raise ValueError("Unsupported code = {} for aider.".format(self.code))
+            raise ValueError("Unsupported code = {} for prefixer.".format(self.code))
 
         #if ked and not self.verify(ked):
             #raise DerivationError("Error verifying derived aid = {} with code "

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -25,7 +25,7 @@ from ..kering import Versionage, Version
 from ..help.helping import mdict
 
 from .coring import Versify, Serials, Ilks, CryOneDex
-from .coring import Signer, Verfer, Diger, Nexter, Aider, Serder
+from .coring import Signer, Verfer, Diger, Nexter, Prefixer, Serder
 from .coring import SigCounter, Siger
 
 ICP_LABELS = ["vs", "aid", "sn", "ilk", "sith", "keys", "nxt",
@@ -157,12 +157,12 @@ def incept(
                )
 
     if code is None and len(keys) == 1:
-        aider = Aider(qb64=keys[0])
+        prefixer = Prefixer(qb64=keys[0])
     else:
         # raises derivation error if non-empty nxt but ephemeral code
-        aider = Aider(ked=ked, code=code)  # Derive AID from ked and code
+        prefixer = Prefixer(ked=ked, code=code)  # Derive AID from ked and code
 
-    ked["aid"] = aider.qb64  # update aid element in ked with aid qb64
+    ked["aid"] = prefixer.qb64  # update aid element in ked with aid qb64
 
     return Serder(ked=ked)  # return serialized ked
 
@@ -332,7 +332,7 @@ class Kever:
 
     Attributes:
         .version is version of current event state
-        .aider is aider instance of current event state
+        .prefixer is prefixer instance for current event state
         .sn is sequence number int
         .diger is Diger instance with digest of current event not prior event
         .ilk is str of current event type
@@ -407,10 +407,10 @@ class Kever:
             raise ValidationError("Failure verifying signatures = {} for {}"
                                   "".format(sigers, serder))
 
-        self.aider = Aider(qb64=ked["aid"])
-        if not self.aider.verify(ked=ked):  # invalid aid
+        self.prefixer = Prefixer(qb64=ked["aid"])
+        if not self.prefixer.verify(ked=ked):  # invalid aid
             raise ValidationError("Invalid aid = {} for inception ked = {}."
-                                  "".format(self.aider.qb64, ked))
+                                  "".format(self.prefixer.qb64, ked))
 
         self.sn = int(ked["sn"], 16)
         if self.sn != 0:
@@ -449,7 +449,7 @@ class Kever:
             if "trait" in d and d["trait"] == TraitDex.EstOnly:
                 self.estOnly = True
 
-        aid = self.aider.qb64
+        aid = self.prefixer.qb64
         dig = self.diger.qb64
         # need this to recognize recovery events
         self.lastEst = Location(sn=self.sn, dig=dig)  # last establishment event location
@@ -484,9 +484,9 @@ class Kever:
         dig = ked["dig"]
         ilk = ked["ilk"]
 
-        if aid != self.aider.qb64:
+        if aid != self.prefixer.qb64:
             raise ValidationError("Mismatch event aid = {} expecting"
-                                  " = {}.".format(aid, self.aider.qb64))
+                                  " = {}.".format(aid, self.prefixer.qb64))
 
         if ilk == Ilks.rot:  # subsequent rotation event
             for k in ROT_LABELS:
@@ -530,7 +530,7 @@ class Kever:
 
             if self.nexter is None:   # empty so rotations not allowed
                 raise ValidationError("Attempted rotation for nontransferable"
-                                      " aid = {}".format(self.aider.qb64))
+                                      " aid = {}".format(self.prefixer.qb64))
 
             verfers = serder.verfers  # only for establishment events
 
@@ -621,8 +621,8 @@ class Kever:
 
             # update logs
             entry = LogEntry(serder=serder, sigers=sigers)
-            self.logs.kels[self.aider.qb64].add(ked["sn"], entry)  # multiple values each sn hex str
-            self.logs.kedls[self.aider.qb64][self.diger.qb64] = entry
+            self.logs.kels[self.prefixer.qb64].add(ked["sn"], entry)  # multiple values each sn hex str
+            self.logs.kedls[self.prefixer.qb64][self.diger.qb64] = entry
 
 
         elif ilk == Ilks.ixn:  # subsequent interaction event
@@ -664,8 +664,8 @@ class Kever:
 
             # update logs
             entry = LogEntry(serder=serder, sigers=sigers)
-            self.logs.kels[self.aider.qb64].add(ked["sn"], entry)  # multiple values each sn hex str
-            self.logs.kedls[self.aider.qb64][self.diger.qb64] = entry
+            self.logs.kels[self.prefixer.qb64].add(ked["sn"], entry)  # multiple values each sn hex str
+            self.logs.kedls[self.prefixer.qb64][self.diger.qb64] = entry
 
 
         else:  # unsupported event ilk so discard
@@ -799,10 +799,10 @@ class Kevery:
         # fetch ked ilk  aid, sn, dig to see how to process
         ked = serder.ked
         try:  # see if aid in event validates
-            aider = Aider(qb64=ked["aid"])
+            prefixer = Prefixer(qb64=ked["aid"])
         except Exception as ex:
             raise ValidationError("Invalid aid = {}.".format(ked["aid"]))
-        aid = aider.qb64
+        aid = prefixer.qb64
         ked = serder.ked
         ilk = ked["ilk"]
         try:
@@ -898,10 +898,10 @@ class Kevery:
         # fetch ked ilk  aid, sn, dig to see how to process
         ked = serder.ked
         try:  # see if aid in event validates
-            aider = Aider(qb64=ked["aid"])
+            prefixer = Prefixer(qb64=ked["aid"])
         except Exception as ex:
             raise ValidationError("Invalid aid = {}.".format(ked["aid"]))
-        aid = aider.qb64
+        aid = prefixer.qb64
         ked = serder.ked
         ilk = ked["ilk"]
         try:

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -28,14 +28,14 @@ from .coring import Versify, Serials, Ilks, CryOneDex
 from .coring import Signer, Verfer, Diger, Nexter, Prefixer, Serder
 from .coring import SigCounter, Siger
 
-ICP_LABELS = ["vs", "aid", "sn", "ilk", "sith", "keys", "nxt",
+ICP_LABELS = ["vs", "pre", "sn", "ilk", "sith", "keys", "nxt",
               "toad", "wits", "cnfg"]
-ROT_LABELS = ["vs", "aid", "sn", "ilk", "dig", "sith", "keys", "nxt",
+ROT_LABELS = ["vs", "pre", "sn", "ilk", "dig", "sith", "keys", "nxt",
               "toad", "cuts", "adds", "data"]
-IXN_LABELS = ["vs", "aid", "sn", "ilk", "dig", "data"]
-DIP_LABELS = ["vs", "aid", "sn", "ilk", "sith", "keys", "nxt",
+IXN_LABELS = ["vs", "pre", "sn", "ilk", "dig", "data"]
+DIP_LABELS = ["vs", "pre", "sn", "ilk", "sith", "keys", "nxt",
               "toad", "wits", "perm", "seal"]
-DRT_LABELS = ["vs", "aid", "sn", "ilk", "dig", "sith", "keys", "nxt",
+DRT_LABELS = ["vs", "pre", "sn", "ilk", "dig", "sith", "keys", "nxt",
               "toad", "cuts", "adds", "perm", "seal"]
 
 
@@ -60,28 +60,28 @@ Location = namedtuple("Location", 'sn dig')  # Location of key event
 Logs = namedtuple("Logs", 'kevers kels kedls')
 
 
-Kevers = dict()  # dict of existing Kevers indexed by aid (qb64) of each Kever
-# Generator or Validator KELs as dict of dicts of events keyed by aid (qb64)
+Kevers = dict()  # dict of existing Kevers indexed by pre (qb64) of each Kever
+# Generator or Validator KELs as dict of dicts of events keyed by pre (qb64)
 # then in order by event sn str
 # mdict keys must be subclass of str
 KELs = dict()
-# Witness or Validator KERLs as dict of dicts of events keyed by aid (qb64)
+# Witness or Validator KERLs as dict of dicts of events keyed by pre (qb64)
 # then in order by event sn str
 # mdict keys must be subclass of str
 KERLs = dict()
 # Key Event Digest Log
-# Validator KELDs as dict of dicts of events keyed by aid  then by event dig (qb64)
+# Validator KELDs as dict of dicts of events keyed by pre  then by event dig (qb64)
 KEDLs = dict()
-# Validator Escows as dict of dicts of events keyed by aid (qb64)
+# Validator Escows as dict of dicts of events keyed by pre (qb64)
 # then in order by event sn str
 # mdict keys must be subclass of str
 Escrows = dict()
 # Potential Duplicitous Event Log
-# Validator PDELs as dict of dicts of dup events keyed by aid (qb64)
+# Validator PDELs as dict of dicts of dup events keyed by pre (qb64)
 # then by event dig (qb64)
 PDELs = dict()
 # Verified Duplicitous Event Log
-# Validator DELs as dict of dicts of dup events keyed by aid  (qb64)
+# Validator DELs as dict of dicts of dup events keyed by pre  (qb64)
 # then by event dig (qb64)
 DELs = dict()
 
@@ -145,7 +145,7 @@ def incept(
     cnfg = cnfg if cnfg is not None else []
 
     ked = dict(vs=vs,  # version string
-               aid="",  # qb64 prefix
+               pre="",  # qb64 prefix
                sn="{:x}".format(sn),  # hex string no leading zeros lowercase
                ilk=ilk,
                sith="{:x}".format(sith), # hex string no leading zeros lowercase
@@ -162,12 +162,12 @@ def incept(
         # raises derivation error if non-empty nxt but ephemeral code
         prefixer = Prefixer(ked=ked, code=code)  # Derive AID from ked and code
 
-    ked["aid"] = prefixer.qb64  # update aid element in ked with aid qb64
+    ked["pre"] = prefixer.qb64  # update pre element in ked with pre qb64
 
     return Serder(ked=ked)  # return serialized ked
 
 
-def rotate( aid,
+def rotate( pre,
             keys,
             dig,
             version=Version,
@@ -187,7 +187,7 @@ def rotate( aid,
     Utility function to automate creation of rotation events.
 
      Parameters:
-        aid
+        pre
         keys
         dig
         version
@@ -264,7 +264,7 @@ def rotate( aid,
     data = data if data is not None else []
 
     ked = dict(vs=vs,  # version string
-               aid=aid,  # ab64 prefix
+               pre=pre,  # ab64 prefix
                sn="{:x}".format(sn),  # hex string no leading zeros lowercase
                ilk=ilk,
                dig=dig,
@@ -280,7 +280,7 @@ def rotate( aid,
     return Serder(ked=ked)  # return serialized ked
 
 
-def interact( aid,
+def interact( pre,
               dig,
               version=Version,
               kind=Serials.json,
@@ -293,7 +293,7 @@ def interact( aid,
     Utility function to automate creation of interaction events.
 
      Parameters:
-        aid
+        pre
         dig
         version
         kind
@@ -309,7 +309,7 @@ def interact( aid,
     data = data if data is not None else []
 
     ked = dict(vs=vs,  # version string
-               aid=aid,  # ab64 prefix
+               pre=pre,  # ab64 prefix
                sn="{:x}".format(sn),  # hex string no leading zeros lowercase
                ilk=ilk,
                dig=dig,
@@ -407,9 +407,9 @@ class Kever:
             raise ValidationError("Failure verifying signatures = {} for {}"
                                   "".format(sigers, serder))
 
-        self.prefixer = Prefixer(qb64=ked["aid"])
-        if not self.prefixer.verify(ked=ked):  # invalid aid
-            raise ValidationError("Invalid aid = {} for inception ked = {}."
+        self.prefixer = Prefixer(qb64=ked["pre"])
+        if not self.prefixer.verify(ked=ked):  # invalid prefix
+            raise ValidationError("Invalid prefix = {} for inception ked = {}."
                                   "".format(self.prefixer.qb64, ked))
 
         self.sn = int(ked["sn"], 16)
@@ -449,23 +449,23 @@ class Kever:
             if "trait" in d and d["trait"] == TraitDex.EstOnly:
                 self.estOnly = True
 
-        aid = self.prefixer.qb64
+        pre = self.prefixer.qb64
         dig = self.diger.qb64
         # need this to recognize recovery events
         self.lastEst = Location(sn=self.sn, dig=dig)  # last establishment event location
 
         # update logs
-        if aid in self.logs.kevers:
-            raise ValueError("Kever aid = {} already in kevers log".format(aid))
+        if pre in self.logs.kevers:
+            raise ValueError("Kever prefix = {} already in kevers log".format(pre))
 
-        self.logs.kevers[aid] = self
+        self.logs.kevers[pre] = self
         entry = LogEntry(serder=serder, sigers=sigers)
-        if aid not in self.logs.kels:
-            self.logs.kels[aid] = mdict()  # supports recover forks by sn
-        self.logs.kels[aid].add(ked["sn"], entry)  # multiple values each sn hex str
-        if aid not in self.logs.kedls:
-            self.logs.kedls[aid] = dict()
-        self.logs.kedls[aid][dig] = entry
+        if pre not in self.logs.kels:
+            self.logs.kels[pre] = mdict()  # supports recover forks by sn
+        self.logs.kels[pre].add(ked["sn"], entry)  # multiple values each sn hex str
+        if pre not in self.logs.kedls:
+            self.logs.kedls[pre] = dict()
+        self.logs.kedls[pre][dig] = entry
 
 
     def update(self, serder,  sigers):
@@ -479,14 +479,14 @@ class Kever:
                                   " state.".format(serder))
 
         ked = serder.ked
-        aid = ked["aid"]
+        pre = ked["pre"]
         sn = int(ked["sn"], 16)
         dig = ked["dig"]
         ilk = ked["ilk"]
 
-        if aid != self.prefixer.qb64:
-            raise ValidationError("Mismatch event aid = {} expecting"
-                                  " = {}.".format(aid, self.prefixer.qb64))
+        if pre != self.prefixer.qb64:
+            raise ValidationError("Mismatch event aid prefix = {} expecting"
+                                  " = {}.".format(pre, self.prefixer.qb64))
 
         if ilk == Ilks.rot:  # subsequent rotation event
             for k in ROT_LABELS:
@@ -510,7 +510,7 @@ class Kever:
                     # fetch last entry of prior events at prior sn = sn -1
                     # need KEL for generator use and KERL for validator
 
-                    entry = self.logs.kels[aid].nabone("{:x}".format(sn - 1))
+                    entry = self.logs.kels[pre].nabone("{:x}".format(sn - 1))
                     if dig == entry.serder.dig:
                         raise ValidationError("Mismatch event dig = {} with dig "
                                               "= {} at event sn = {}."
@@ -525,12 +525,12 @@ class Kever:
 
 
             # verify nxt from prior
-            # also check derivation code of aid for non-transferable
+            # also check derivation code of pre for non-transferable
             #  check and
 
             if self.nexter is None:   # empty so rotations not allowed
                 raise ValidationError("Attempted rotation for nontransferable"
-                                      " aid = {}".format(self.prefixer.qb64))
+                                      " prefix = {}".format(self.prefixer.qb64))
 
             verfers = serder.verfers  # only for establishment events
 
@@ -796,13 +796,13 @@ class Kevery:
                 attached signatures.
 
         """
-        # fetch ked ilk  aid, sn, dig to see how to process
+        # fetch ked ilk  pre, sn, dig to see how to process
         ked = serder.ked
-        try:  # see if aid in event validates
-            prefixer = Prefixer(qb64=ked["aid"])
+        try:  # see if pre in event validates
+            prefixer = Prefixer(qb64=ked["pre"])
         except Exception as ex:
-            raise ValidationError("Invalid aid = {}.".format(ked["aid"]))
-        aid = prefixer.qb64
+            raise ValidationError("Invalid pre = {}.".format(ked["pre"]))
+        pre = prefixer.qb64
         ked = serder.ked
         ilk = ked["ilk"]
         try:
@@ -811,7 +811,7 @@ class Kevery:
             raise ValidationError("Invalid sn = {}".format(ked["sn"]))
         dig = serder.dig
 
-        if aid not in self.logs.kevers:  #  first seen event for aid
+        if pre not in self.logs.kevers:  #  first seen event for pre
             if ilk == Ilks.icp:  # first seen and inception so verify event keys
                 # kever init verifies basic inception stuff and signatures
                 # raises exception if problem adds to KEL Kevers
@@ -821,33 +821,33 @@ class Kevery:
 
             else:  # not inception so can't verify, add to escrow
                 # log escrowed
-                if aid not in Escrows:  #  add to Escrows
-                    Escrows[aid] = mdict()  # multiple values by sn
-                if sn not in Escrows[aid]:
-                    Escrows[aid].add(sn, LogEntry(serder=serder, sigers=sigers))
+                if pre not in Escrows:  #  add to Escrows
+                    Escrows[pre] = mdict()  # multiple values by sn
+                if sn not in Escrows[pre]:
+                    Escrows[pre].add(sn, LogEntry(serder=serder, sigers=sigers))
 
 
-        else:  # already accepted inception event for aid
-            if dig in self.logs.kedls[aid]:  #  duplicate event so dicard
+        else:  # already accepted inception event for pre
+            if dig in self.logs.kedls[pre]:  #  duplicate event so dicard
                 # log duplicate
                 return  # discard
 
             if ilk == Ilks.icp:  # inception event so maybe duplicitous
-                if aid not in PDELs:  #  add to PDELs
-                    PDELS[aid] = dict()
-                if dig not in PDELS[aid]:
-                    PDELS[aid][dig] = LogEntry(serder=serder, sigers=sigers)
+                if pre not in PDELs:  #  add to PDELs
+                    PDELS[pre] = dict()
+                if dig not in PDELS[pre]:
+                    PDELS[pre][dig] = LogEntry(serder=serder, sigers=sigers)
 
             else:  # rot or ixn, so sn matters
-                kever = self.logs.kevers[aid]  # get existing kever for aid
+                kever = self.logs.kevers[pre]  # get existing kever for pre
                 sno = kever.sn + 1  # proper sn of new inorder event
 
                 if sn > sno:  # sn later than sno so out of order escrow
                     #  log escrowed
-                    if aid not in Escrows:  #  add to Escrows
-                        Escrows[aid] = mdict()  # multiple values by sn
-                    if sn not in Escrows[aid]:
-                        Escrows[aid].add(sn, LogEntry(serder=serder, sigers=sigers))
+                    if pre not in Escrows:  #  add to Escrows
+                        Escrows[pre] = mdict()  # multiple values by sn
+                    if sn not in Escrows[pre]:
+                        Escrows[pre].add(sn, LogEntry(serder=serder, sigers=sigers))
 
                 elif ((sn == sno) or  # new inorder event
                       (ilk == Ilks.rot and kever.lastEst.sn < sn <= sno )):  # recovery
@@ -856,10 +856,10 @@ class Kevery:
                     kever.update(serder=serder, sigers=sigers)
 
                 else:  # maybe duplicitous
-                    if aid not in PDELs:  #  add to PDELs
-                        PDELs[aid] = dict()
-                    if dig not in PDELS[aid]:
-                        PDELS[aid][dig] = LogEntry(serder=serder, sigers=sigers)
+                    if pre not in PDELs:  #  add to PDELs
+                        PDELs[pre] = dict()
+                    if dig not in PDELS[pre]:
+                        PDELS[pre][dig] = LogEntry(serder=serder, sigers=sigers)
 
 
     def processAll(self, kes):
@@ -895,13 +895,13 @@ class Kevery:
 
         """
 
-        # fetch ked ilk  aid, sn, dig to see how to process
+        # fetch ked ilk  pre, sn, dig to see how to process
         ked = serder.ked
-        try:  # see if aid in event validates
-            prefixer = Prefixer(qb64=ked["aid"])
+        try:  # see if pre in event validates
+            prefixer = Prefixer(qb64=ked["pre"])
         except Exception as ex:
-            raise ValidationError("Invalid aid = {}.".format(ked["aid"]))
-        aid = prefixer.qb64
+            raise ValidationError("Invalid pre = {}.".format(ked["pre"]))
+        pre = prefixer.qb64
         ked = serder.ked
         ilk = ked["ilk"]
         try:
@@ -910,7 +910,7 @@ class Kevery:
             raise ValidationError("Invalid sn = {}".format(ked["sn"]))
         dig = serder.dig
 
-        if dig in KEDLs["aid"]:
+        if dig in KEDLs["pre"]:
             return
 
         if ilk == Ilks.icp:  # inception event so maybe duplicitous
@@ -920,10 +920,10 @@ class Kevery:
             kever = Kever(serder=serder, sigers=sigers)  # create kever from serder
             # No exception above so verified duplicitous event
             # log it and add to DELS if first time
-            if aid not in DELs:  #  add to DELS
-                DELs[aid] = dict()
-            if dig not in DELS[aid]:
-                DELS[aid][dig] = LogEntry(serder=serder, sigers=sigers)
+            if pre not in DELs:  #  add to DELS
+                DELs[pre] = dict()
+            if dig not in DELS[pre]:
+                DELS[pre][dig] = LogEntry(serder=serder, sigers=sigers)
 
         else:
             pass

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -613,7 +613,7 @@ def test_prefixer():
     cnfg = []
 
     ked = dict(vs=vs,  # version string
-               aid="",  # qb64 prefix
+               pre="",  # qb64 prefix
                sn="{:x}".format(sn),  # hex string no leading zeros lowercase
                ilk=ilk,
                sith="{:x}".format(sith), # hex string no leading zeros lowercase
@@ -631,7 +631,7 @@ def test_prefixer():
 
     nexter = Nexter(sith=1, keys=[nxtfer.qb64])
     ked = dict(vs=vs,  # version string
-               aid="",  # qb64 prefix
+               pre="",  # qb64 prefix
                sn="{:x}".format(sn),  # hex string no leading zeros lowercase
                ilk=ilk,
                sith="{:x}".format(sith), # hex string no leading zeros lowercase
@@ -647,13 +647,13 @@ def test_prefixer():
     assert prefixer.verify(ked=ked) == True
 
     perm = []
-    seal = dict(aid = 'EXpGDy9FxDESc974WW86xDxM0fQgKjhDWOklCXtstkus',
+    seal = dict(pre = 'EXpGDy9FxDESc974WW86xDxM0fQgKjhDWOklCXtstkus',
                 sn  = '2',
                 ilk = Ilks.ixn,
                 dig = 'E03rxRmMcP2-I2Gd0sUhlYwjk8KEz5gNGxPwPg-sGJds')
 
     ked = dict(vs=vs,  # version string
-               aid="",  # qb64 prefix
+               pre="",  # qb64 prefix
                sn="{:x}".format(sn),  # hex string no leading zeros lowercase
                ilk=Ilks.dip,
                sith="{:x}".format(sith), # hex string no leading zeros lowercase
@@ -690,7 +690,7 @@ def test_prefixer():
 
     nexter = Nexter(sith=1, keys=[nxtfer.qb64])
     ked = dict(vs=vs,  # version string
-               aid="",  # qb64 prefix
+               pre="",  # qb64 prefix
                sn="{:x}".format(sn),  # hex string no leading zeros lowercase
                ilk=ilk,
                sith="{:x}".format(sith), # hex string no leading zeros lowercase
@@ -992,7 +992,7 @@ def test_serials():
 
 
     icp = dict(vs = Vstrings.json,
-              aid = 'AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM',
+              pre = 'AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM',
               sn = '0001',
               ilk = 'icp',
               dig = 'DVPzhzS6b5CMaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfS',
@@ -1005,7 +1005,7 @@ def test_serials():
              )
 
     rot = dict(vs = Vstrings.json,
-              aid = 'AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM',
+              pre = 'AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM',
               sn = '0001',
               ilk = 'rot',
               dig = 'DVPzhzS6b5CMaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfS',
@@ -1020,7 +1020,7 @@ def test_serials():
 
     icps = json.dumps(icp, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
     assert len(icps) == 303
-    assert icps == (b'{"vs":"KERI10JSON000000_","aid":"AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM'
+    assert icps == (b'{"vs":"KERI10JSON000000_","pre":"AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM'
                     b'","sn":"0001","ilk":"icp","dig":"DVPzhzS6b5CMaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAf'
                     b'S","sith":1,"keys":["AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"],"nxt":"'
                     b'DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM","toad":0,"wits":[],"cnfg":[]}')
@@ -1030,7 +1030,7 @@ def test_serials():
 
     rots = json.dumps(rot, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
     assert len(rots) == 313
-    assert rots == (b'{"vs":"KERI10JSON000000_","aid":"AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM'
+    assert rots == (b'{"vs":"KERI10JSON000000_","pre":"AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM'
                     b'","sn":"0001","ilk":"rot","dig":"DVPzhzS6b5CMaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAf'
                     b'S","sith":1,"keys":["AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"],"nxt":"'
                     b'DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM","toad":0,"cuts":[],"adds":[],"'
@@ -1042,7 +1042,7 @@ def test_serials():
     icp["vs"] = Vstrings.mgpk
     icps = msgpack.dumps(icp)
     assert len(icps) == 264
-    assert icps == (b'\x8b\xa2vs\xb1KERI10MGPK000000_\xa3aid\xd9,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAf'
+    assert icps == (b'\x8b\xa2vs\xb1KERI10MGPK000000_\xa3pre\xd9,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAf'
                     b'SVPzhzS6b5CM\xa2sn\xa40001\xa3ilk\xa3icp\xa3dig\xd9,DVPzhzS6b5CMaU6JR2nmwy'
                     b'Z-i0d8JZAoTNZH3ULvYAfS\xa4sith\x01\xa4keys\x91\xd9,AaU6JR2nmwyZ-i0d8JZAoTNZ'
                     b'H3ULvYAfSVPzhzS6b5CM\xa3nxt\xd9,DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5'
@@ -1055,7 +1055,7 @@ def test_serials():
     rot["vs"] = Vstrings.mgpk
     rots = msgpack.dumps(rot)
     assert len(rots) == 270
-    assert rots == (b'\x8c\xa2vs\xb1KERI10MGPK000000_\xa3aid\xd9,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAf'
+    assert rots == (b'\x8c\xa2vs\xb1KERI10MGPK000000_\xa3pre\xd9,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAf'
                     b'SVPzhzS6b5CM\xa2sn\xa40001\xa3ilk\xa3rot\xa3dig\xd9,DVPzhzS6b5CMaU6JR2nmwy'
                     b'Z-i0d8JZAoTNZH3ULvYAfS\xa4sith\x01\xa4keys\x91\xd9,AaU6JR2nmwyZ-i0d8JZAoTNZ'
                     b'H3ULvYAfSVPzhzS6b5CM\xa3nxt\xd9,DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5'
@@ -1069,10 +1069,11 @@ def test_serials():
     icp["vs"] = Vstrings.cbor
     icps = cbor.dumps(icp)
     assert len(icps) == 264
-    assert icps == (b'\xabbvsqKERI10CBOR000000_caidx,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM'
-                     b'bsnd0001cilkcicpcdigx,DVPzhzS6b5CMaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSdsith\x01'
-                     b'dkeys\x81x,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CMcnxtx,DZ-i0d8JZAoTNZ'
-                     b'H3ULvaU6JR2nmwyYAfSVPzhzS6b5CMdtoad\x00dwits\x80dcnfg\x80')
+    assert icps == (b'\xabbvsqKERI10CBOR000000_cprex,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM'
+                    b'bsnd0001cilkcicpcdigx,DVPzhzS6b5CMaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSdsith\x01'
+                    b'dkeys\x81x,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CMcnxtx,DZ-i0d8JZAoTNZ'
+                    b'H3ULvaU6JR2nmwyYAfSVPzhzS6b5CMdtoad\x00dwits\x80dcnfg\x80')
+
 
 
     match = Rever.search(icps)
@@ -1081,7 +1082,7 @@ def test_serials():
     rot["vs"] = Vstrings.cbor
     rots = cbor.dumps(rot)
     assert len(rots) == 270
-    assert rots == (b'\xacbvsqKERI10CBOR000000_caidx,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM'
+    assert rots == (b'\xacbvsqKERI10CBOR000000_cprex,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM'
                     b'bsnd0001cilkcrotcdigx,DVPzhzS6b5CMaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSdsith\x01'
                     b'dkeys\x81x,AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CMcnxtx,DZ-i0d8JZAoTNZ'
                     b'H3ULvaU6JR2nmwyYAfSVPzhzS6b5CMdtoad\x00dcuts\x80dadds\x80ddata\x80')
@@ -1112,7 +1113,7 @@ def test_serder():
         serder = Serder()
 
 
-    e1 = dict(vs=Vstrings.json, aid="ABCDEFG", sn="0001", ilk="rot")
+    e1 = dict(vs=Vstrings.json, pre="ABCDEFG", sn="0001", ilk="rot")
     serder = Serder(ked=e1)
 
     e1s = json.dumps(e1, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
@@ -1196,7 +1197,7 @@ def test_serder():
     assert len(evt1.diger.raw) == 32
     assert len(evt1.dig) == 44
     assert len(evt1.dig) == CryOneSizes[CryOneDex.Blake3_256]
-    assert evt1.dig == 'EWRKo-8KjGqPxHBsd77LfTy5sHBkfql6NOwl0-8VoI3U'
+    assert evt1.dig == 'EaDVEkrFdx8W0ZZAsfwf9mjxhgBt6PvfCmFPdr7RIcfY'
     assert evt1.diger.verify(evt1.raw)
 
     evt1 = Serder(ked=ked1)

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -21,7 +21,7 @@ from keri.core.coring import CrySelDex, CryOneDex, CryTwoDex, CryFourDex
 from keri.core.coring import CryOneSizes, CryOneRawSizes, CryTwoSizes, CryTwoRawSizes
 from keri.core.coring import CryFourSizes, CryFourRawSizes, CrySizes, CryRawSizes
 from keri.core.coring import CryMat, Verfer, Sigver, Signer, Diger, Nexter
-from keri.core.coring import Aider
+from keri.core.coring import Prefixer
 from keri.core.coring import generateSigners,  generateSecrets
 from keri.core.coring import SigSelDex
 from keri.core.coring import SigCntDex, SigCntSizes, SigCntRawSizes
@@ -534,9 +534,9 @@ def test_nexter():
 
 
 
-def test_aider():
+def test_prefixer():
     """
-    Test the support functionality for aider subclass of crymat
+    Test the support functionality for prefixer subclass of crymat
     """
 
     # verkey,  sigkey = pysodium.crypto_sign_keypair()
@@ -551,62 +551,62 @@ def test_aider():
     assert nxtfer.qb64 == 'Dpl-JNEryNVTBgyMGmEym7xqzaOpBOngn2gSIssRf9gA'
 
     with pytest.raises(EmptyMaterialError):
-        aider = Aider()
+        prefixer = Prefixer()
 
     with pytest.raises(ValueError):
-        aider = Aider(raw=verkey, code=CryOneDex.SHA2_256)
+        prefixer = Prefixer(raw=verkey, code=CryOneDex.SHA2_256)
 
 
     # test creation given raw and code no derivation
-    aider = Aider(raw=verkey)  # defaults provide Ed25519N aider
-    assert aider.code == CryOneDex.Ed25519N
-    assert len(aider.raw) == CryOneRawSizes[aider.code]
-    assert len(aider.qb64) == CryOneSizes[aider.code]
+    prefixer = Prefixer(raw=verkey)  # defaults provide Ed25519N prefixer
+    assert prefixer.code == CryOneDex.Ed25519N
+    assert len(prefixer.raw) == CryOneRawSizes[prefixer.code]
+    assert len(prefixer.qb64) == CryOneSizes[prefixer.code]
 
-    ked = dict(keys=[aider.qb64], nxt="")
-    assert aider.verify(ked=ked) == True
+    ked = dict(keys=[prefixer.qb64], nxt="")
+    assert prefixer.verify(ked=ked) == True
 
-    ked = dict(keys=[aider.qb64], nxt="ABC")
-    assert aider.verify(ked=ked) == False
+    ked = dict(keys=[prefixer.qb64], nxt="ABC")
+    assert prefixer.verify(ked=ked) == False
 
-    aider = Aider(raw=verkey, code=CryOneDex.Ed25519)  # defaults provide Ed25519N aider
-    assert aider.code == CryOneDex.Ed25519
-    assert len(aider.raw) == CryOneRawSizes[aider.code]
-    assert len(aider.qb64) == CryOneSizes[aider.code]
+    prefixer = Prefixer(raw=verkey, code=CryOneDex.Ed25519)  # defaults provide Ed25519N prefixer
+    assert prefixer.code == CryOneDex.Ed25519
+    assert len(prefixer.raw) == CryOneRawSizes[prefixer.code]
+    assert len(prefixer.qb64) == CryOneSizes[prefixer.code]
 
-    ked = dict(keys=[aider.qb64])
-    assert aider.verify(ked=ked) == True
+    ked = dict(keys=[prefixer.qb64])
+    assert prefixer.verify(ked=ked) == True
 
     verfer = Verfer(raw=verkey, code=CryOneDex.Ed25519)
-    aider = Aider(raw=verfer.raw)
-    assert aider.code == CryOneDex.Ed25519N
-    assert aider.verify(ked=ked) == False
+    prefixer = Prefixer(raw=verfer.raw)
+    assert prefixer.code == CryOneDex.Ed25519N
+    assert prefixer.verify(ked=ked) == False
 
     # Test basic derivation from ked
     ked = dict(keys=[verfer.qb64], nxt="")
-    aider = Aider(ked=ked, code=CryOneDex.Ed25519)
-    assert aider.qb64 == verfer.qb64
-    assert aider.verify(ked=ked) == True
+    prefixer = Prefixer(ked=ked, code=CryOneDex.Ed25519)
+    assert prefixer.qb64 == verfer.qb64
+    assert prefixer.verify(ked=ked) == True
 
     with pytest.raises(DerivationError):
-        aider = Aider(ked=ked)
+        prefixer = Prefixer(ked=ked)
 
     verfer = Verfer(raw=verkey, code=CryOneDex.Ed25519N)
     ked = dict(keys=[verfer.qb64], nxt="")
-    aider = Aider(ked=ked)
-    assert aider.qb64 == verfer.qb64
-    assert aider.verify(ked=ked) == True
+    prefixer = Prefixer(ked=ked)
+    assert prefixer.qb64 == verfer.qb64
+    assert prefixer.verify(ked=ked) == True
 
     ked = dict(keys=[verfer.qb64], nxt="ABCD")
     with pytest.raises(DerivationError):
-        aider = Aider(ked=ked)
+        prefixer = Prefixer(ked=ked)
 
     # Test digest derivation from inception ked
     vs = Versify(version=Version, kind=Serials.json, size=0)
     sn = 0
     ilk = Ilks.icp
     sith = 1
-    keys = [Aider(raw=verkey, code=CryOneDex.Ed25519).qb64]
+    keys = [Prefixer(raw=verkey, code=CryOneDex.Ed25519).qb64]
     nxt = ""
     toad = 0
     wits = []
@@ -624,9 +624,9 @@ def test_aider():
                cnfg=cnfg,  # list of config ordered mappings may be empty
                )
 
-    aider = Aider(ked=ked, code=CryOneDex.Blake3_256)
-    assert aider.qb64 == 'E03rxRmMcP2-I2Gd0sUhlYwjk8KEz5gNGxPwPg-sGJds'
-    assert aider.verify(ked=ked) == True
+    prefixer = Prefixer(ked=ked, code=CryOneDex.Blake3_256)
+    assert prefixer.qb64 == 'E03rxRmMcP2-I2Gd0sUhlYwjk8KEz5gNGxPwPg-sGJds'
+    assert prefixer.verify(ked=ked) == True
 
 
     nexter = Nexter(sith=1, keys=[nxtfer.qb64])
@@ -642,9 +642,9 @@ def test_aider():
                cnfg=cnfg,  # list of config ordered mappings may be empty
                )
 
-    aider = Aider(ked=ked, code=CryOneDex.Blake3_256)
-    assert aider.qb64 == 'EXpGDy9FxDESc974WW86xDxM0fQgKjhDWOklCXtstkus'
-    assert aider.verify(ked=ked) == True
+    prefixer = Prefixer(ked=ked, code=CryOneDex.Blake3_256)
+    assert prefixer.qb64 == 'EXpGDy9FxDESc974WW86xDxM0fQgKjhDWOklCXtstkus'
+    assert prefixer.verify(ked=ked) == True
 
     perm = []
     seal = dict(aid = 'EXpGDy9FxDESc974WW86xDxM0fQgKjhDWOklCXtstkus',
@@ -665,9 +665,9 @@ def test_aider():
                seal=seal
                )
 
-    aider = Aider(ked=ked, code=CryOneDex.Blake3_256)
-    assert aider.qb64 == 'EQrpcQ1RX0jDKcBbGXWZra3dr3bFyz6Ly1icEBlgD20s'
-    assert aider.verify(ked=ked) == True
+    prefixer = Prefixer(ked=ked, code=CryOneDex.Blake3_256)
+    assert prefixer.qb64 == 'EQrpcQ1RX0jDKcBbGXWZra3dr3bFyz6Ly1icEBlgD20s'
+    assert prefixer.verify(ked=ked) == True
 
     #  Test signature derivation
 
@@ -701,13 +701,13 @@ def test_aider():
                cnfg=cnfg,  # list of config ordered mappings may be empty
                )
 
-    aider = Aider(ked=ked, code=CryTwoDex.Ed25519, seed=seed)
-    assert aider.qb64 == '0BSb9qBNXUerVs4IDYnai29AXcPQJtudLPfzfvehicA7LrswWBPmNlNQK9gIJB4pny2YpuB3m6-pgyl4cU65RRCA'
-    assert aider.verify(ked=ked) == True
+    prefixer = Prefixer(ked=ked, code=CryTwoDex.Ed25519, seed=seed)
+    assert prefixer.qb64 == '0BSb9qBNXUerVs4IDYnai29AXcPQJtudLPfzfvehicA7LrswWBPmNlNQK9gIJB4pny2YpuB3m6-pgyl4cU65RRCA'
+    assert prefixer.verify(ked=ked) == True
 
-    aider = Aider(ked=ked, code=CryTwoDex.Ed25519, secret=secret)
-    assert aider.qb64 == '0BSb9qBNXUerVs4IDYnai29AXcPQJtudLPfzfvehicA7LrswWBPmNlNQK9gIJB4pny2YpuB3m6-pgyl4cU65RRCA'
-    assert aider.verify(ked=ked) == True
+    prefixer = Prefixer(ked=ked, code=CryTwoDex.Ed25519, secret=secret)
+    assert prefixer.qb64 == '0BSb9qBNXUerVs4IDYnai29AXcPQJtudLPfzfvehicA7LrswWBPmNlNQK9gIJB4pny2YpuB3m6-pgyl4cU65RRCA'
+    assert prefixer.verify(ked=ked) == True
 
     """ Done Test """
 
@@ -1290,4 +1290,4 @@ def test_serder():
 
 
 if __name__ == "__main__":
-    test_aider()
+    test_prefixer()

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -15,7 +15,7 @@ from keri.kering import ValidationError, EmptyMaterialError, DerivationError
 from keri.core.coring import CrySelDex, CryOneDex, CryTwoDex, CryFourDex
 from keri.core.coring import CryOneSizes, CryOneRawSizes, CryTwoSizes, CryTwoRawSizes
 from keri.core.coring import CryFourSizes, CryFourRawSizes, CrySizes, CryRawSizes
-from keri.core.coring import CryMat, Verfer, Signer, Diger, Nexter, Aider
+from keri.core.coring import CryMat, Verfer, Signer, Diger, Nexter, Prefixer
 from keri.core.coring import generateSigners
 from keri.core.coring import SigSelDex, SigTwoDex, SigTwoSizes, SigTwoRawSizes
 from keri.core.coring import SigFourDex, SigFourSizes, SigFourRawSizes
@@ -198,7 +198,7 @@ def test_kever():
 
 
     # Derive AID from ked
-    aid0 = Aider(ked=ked0, code = CryOneDex.Ed25519)
+    aid0 = Prefixer(ked=ked0, code = CryOneDex.Ed25519)
     assert aid0.code == CryOneDex.Ed25519
     assert aid0.qb64 == skp0.verfer.qb64
 
@@ -286,7 +286,7 @@ def test_keyeventsequence_0():
     assert signers[0].verfer.verify(sig0.raw, serder0.raw)
     # create key event verifier state
     kever = Kever(serder=serder0, sigers=[sig0])
-    assert kever.aider.qb64 == aid
+    assert kever.prefixer.qb64 == aid
     assert kever.sn == 0
     assert kever.diger.qb64 == serder0.dig
     assert kever.ilk == Ilks.icp
@@ -316,7 +316,7 @@ def test_keyeventsequence_0():
     assert signers[1].verfer.verify(sig1.raw, serder1.raw)
     # update key event verifier state
     kever.update(serder=serder1, sigers=[sig1])
-    assert kever.aider.qb64 == aid
+    assert kever.prefixer.qb64 == aid
     assert kever.sn == 1
     assert kever.diger.qb64 == serder1.dig
     assert kever.ilk == Ilks.rot
@@ -340,7 +340,7 @@ def test_keyeventsequence_0():
     assert signers[2].verfer.verify(sig2.raw, serder2.raw)
     # update key event verifier state
     kever.update(serder=serder2, sigers=[sig2])
-    assert kever.aider.qb64 == aid
+    assert kever.prefixer.qb64 == aid
     assert kever.sn == 2
     assert kever.diger.qb64 == serder2.dig
     assert kever.ilk == Ilks.rot
@@ -358,7 +358,7 @@ def test_keyeventsequence_0():
     assert signers[2].verfer.verify(sig3.raw, serder3.raw)
     # update key event verifier state
     kever.update(serder=serder3, sigers=[sig3])
-    assert kever.aider.qb64 == aid
+    assert kever.prefixer.qb64 == aid
     assert kever.sn == 3
     assert kever.diger.qb64 == serder3.dig
     assert kever.ilk == Ilks.ixn
@@ -376,7 +376,7 @@ def test_keyeventsequence_0():
     assert signers[2].verfer.verify(sig4.raw, serder4.raw)
     # update key event verifier state
     kever.update(serder=serder4, sigers=[sig4])
-    assert kever.aider.qb64 == aid
+    assert kever.prefixer.qb64 == aid
     assert kever.sn == 4
     assert kever.diger.qb64 == serder4.dig
     assert kever.ilk == Ilks.ixn
@@ -400,7 +400,7 @@ def test_keyeventsequence_0():
     assert signers[3].verfer.verify(sig5.raw, serder5.raw)
     # update key event verifier state
     kever.update(serder=serder5, sigers=[sig5])
-    assert kever.aider.qb64 == aid
+    assert kever.prefixer.qb64 == aid
     assert kever.sn == 5
     assert kever.diger.qb64 == serder5.dig
     assert kever.ilk == Ilks.rot
@@ -418,7 +418,7 @@ def test_keyeventsequence_0():
     assert signers[3].verfer.verify(sig6.raw, serder6.raw)
     # update key event verifier state
     kever.update(serder=serder6, sigers=[sig6])
-    assert kever.aider.qb64 == aid
+    assert kever.prefixer.qb64 == aid
     assert kever.sn == 6
     assert kever.diger.qb64 == serder6.dig
     assert kever.ilk == Ilks.ixn
@@ -439,7 +439,7 @@ def test_keyeventsequence_0():
     assert signers[4].verfer.verify(sig7.raw, serder7.raw)
     # update key event verifier state
     kever.update(serder=serder7, sigers=[sig7])
-    assert kever.aider.qb64 == aid
+    assert kever.prefixer.qb64 == aid
     assert kever.sn == 7
     assert kever.diger.qb64 == serder7.dig
     assert kever.ilk == Ilks.rot
@@ -534,7 +534,7 @@ def test_keyeventsequence_1():
     assert signers[0].verfer.verify(sig0.raw, serder0.raw)
     # create key event verifier state
     kever = Kever(serder=serder0, sigers=[sig0])
-    assert kever.aider.qb64 == aid
+    assert kever.prefixer.qb64 == aid
     assert kever.sn == 0
     assert kever.diger.qb64 == serder0.dig
     assert kever.ilk == Ilks.icp
@@ -577,7 +577,7 @@ def test_keyeventsequence_1():
     assert signers[1].verfer.verify(sig1.raw, serder1.raw)
     # update key event verifier state
     kever.update(serder=serder1, sigers=[sig1])
-    assert kever.aider.qb64 == aid
+    assert kever.prefixer.qb64 == aid
     assert kever.sn == 1
     assert kever.diger.qb64 == serder1.dig
     assert kever.ilk == Ilks.rot
@@ -634,7 +634,7 @@ def test_kevery():
                             b'nk4O6glvxx3bJ8Zfgg606DA')
 
     # Event 1 Rotation Transferable
-    serder = rotate(aid=kever.aider.qb64,
+    serder = rotate(aid=kever.prefixer.qb64,
                     keys=[signers[1].verfer.qb64],
                     dig=kever.diger.qb64,
                     nxt=Nexter(keys=[signers[2].verfer.qb64]).qb64,
@@ -651,7 +651,7 @@ def test_kevery():
     kes.extend(siger.qb64b)
 
     # Event 2 Rotation Transferable
-    serder = rotate(aid=kever.aider.qb64,
+    serder = rotate(aid=kever.prefixer.qb64,
                     keys=[signers[2].verfer.qb64],
                     dig=kever.diger.qb64,
                     nxt=Nexter(keys=[signers[3].verfer.qb64]).qb64,
@@ -668,7 +668,7 @@ def test_kevery():
     kes.extend(siger.qb64b)
 
     # Event 3 Interaction
-    serder = interact(aid=kever.aider.qb64,
+    serder = interact(aid=kever.prefixer.qb64,
                       dig=kever.diger.qb64,
                       sn=3)
     # create sig counter
@@ -683,7 +683,7 @@ def test_kevery():
     kes.extend(siger.qb64b)
 
     # Event 4 Interaction
-    serder = interact(aid=kever.aider.qb64,
+    serder = interact(aid=kever.prefixer.qb64,
                       dig=kever.diger.qb64,
                       sn=4)
     # create sig counter
@@ -698,7 +698,7 @@ def test_kevery():
     kes.extend(siger.qb64b)
 
     # Event 5 Rotation Transferable
-    serder = rotate(aid=kever.aider.qb64,
+    serder = rotate(aid=kever.prefixer.qb64,
                     keys=[signers[3].verfer.qb64],
                     dig=kever.diger.qb64,
                     nxt=Nexter(keys=[signers[4].verfer.qb64]).qb64,
@@ -715,7 +715,7 @@ def test_kevery():
     kes.extend(siger.qb64b)
 
     # Event 6 Interaction
-    serder = interact(aid=kever.aider.qb64,
+    serder = interact(aid=kever.prefixer.qb64,
                       dig=kever.diger.qb64,
                       sn=6)
     # create sig counter
@@ -731,7 +731,7 @@ def test_kevery():
 
     # Event 7 Rotation to null NonTransferable Abandon
    # nxt digest is empty
-    serder = rotate(aid=kever.aider.qb64,
+    serder = rotate(aid=kever.prefixer.qb64,
                 keys=[signers[4].verfer.qb64],
                 dig=kever.diger.qb64,
                 nxt="",
@@ -748,7 +748,7 @@ def test_kevery():
     kes.extend(siger.qb64b)
 
     # Event 8 Interaction
-    serder = interact(aid=kever.aider.qb64,
+    serder = interact(aid=kever.prefixer.qb64,
                       dig=kever.diger.qb64,
                       sn=8)
     # create sig counter
@@ -764,7 +764,7 @@ def test_kevery():
     kes.extend(siger.qb64b)
 
     # Event 8 Rotation
-    serder = rotate(aid=kever.aider.qb64,
+    serder = rotate(aid=kever.prefixer.qb64,
                     keys=[signers[4].verfer.qb64],
                     dig=kever.diger.qb64,
                     nxt=Nexter(keys=[signers[5].verfer.qb64]).qb64,
@@ -788,7 +788,7 @@ def test_kevery():
     kevery = Kevery(logs=klogs)
     kevery.processAll(kes=kes)
 
-    aid = kever.aider.qb64
+    aid = kever.prefixer.qb64
     assert aid in klogs.kevers
     vkever = klogs.kevers[aid]
     assert vkever.sn == kever.sn
@@ -864,7 +864,7 @@ def test_multisig_digaid():
     keys = nxtkeys
     sith = 2
     nxtkeys = [signers[5].verfer.qb64, signers[6].verfer.qb64, signers[7].verfer.qb64]
-    serder = rotate(aid=kever.aider.qb64,
+    serder = rotate(aid=kever.prefixer.qb64,
                     keys=keys,
                     sith=sith,
                     dig=kever.diger.qb64,
@@ -885,7 +885,7 @@ def test_multisig_digaid():
 
 
     # Event 2 Interaction
-    serder = interact(aid=kever.aider.qb64,
+    serder = interact(aid=kever.prefixer.qb64,
                       dig=kever.diger.qb64,
                       sn=2)
     # create sig counter
@@ -901,7 +901,7 @@ def test_multisig_digaid():
         kes.extend(siger.qb64b)
 
     # Event 4 Interaction
-    serder = interact(aid=kever.aider.qb64,
+    serder = interact(aid=kever.prefixer.qb64,
                       dig=kever.diger.qb64,
                       sn=3)
     # create sig counter
@@ -919,7 +919,7 @@ def test_multisig_digaid():
     # Event 7 Rotation to null NonTransferable Abandon
     # nxt digest is empty
     keys = nxtkeys
-    serder = rotate(aid=kever.aider.qb64,
+    serder = rotate(aid=kever.prefixer.qb64,
                 keys=keys,
                 sith=2,
                 dig=kever.diger.qb64,
@@ -945,7 +945,7 @@ def test_multisig_digaid():
     kevery = Kevery(logs=klogs)
     kevery.processAll(kes=kes)
 
-    aid = kever.aider.qb64
+    aid = kever.prefixer.qb64
     assert aid in klogs.kevers
     vkever = klogs.kevers[aid]
     assert vkever.sn == kever.sn
@@ -966,7 +966,7 @@ def test_process_nontransferable():
     assert skp0.verfer.code == CryOneDex.Ed25519N
 
     # Derive AID by merely assigning verifier public key
-    aid0 = Aider(qb64=skp0.verfer.qb64)
+    aid0 = Prefixer(qb64=skp0.verfer.qb64)
     assert aid0.code == CryOneDex.Ed25519N
 
     # Ephemeral may be used without inception event
@@ -1030,7 +1030,7 @@ def test_process_nontransferable():
         del msgb0[:len(rsig.qb64)]
 
     # verify aid
-    raid0 = Aider(qb64=rser0.ked["aid"])
+    raid0 = Prefixer(qb64=rser0.ked["aid"])
     assert raid0.verify(ked=rser0.ked)
     """ Done Test """
 
@@ -1074,7 +1074,7 @@ def test_process_transferable():
 
 
     # Derive AID from ked
-    aid0 = Aider(ked=ked0, code=CryOneDex.Ed25519)
+    aid0 = Prefixer(ked=ked0, code=CryOneDex.Ed25519)
     assert aid0.code == CryOneDex.Ed25519
     assert aid0.qb64 == skp0.verfer.qb64
 
@@ -1119,7 +1119,7 @@ def test_process_transferable():
         del msgb0[:len(rsig.qb64)]
 
     # verify aid
-    raid0 = Aider(qb64=rser0.ked["aid"])
+    raid0 = Prefixer(qb64=rser0.ked["aid"])
     assert raid0.verify(ked=rser0.ked)
 
     #verify nxt digest from event is still valid

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -66,9 +66,9 @@ def test_keyeventfuncs():
     assert signer0.verfer.code == CryOneDex.Ed25519N
     keys0 = [signer0.verfer.qb64]
     serder = incept(keys=keys0)  #  default nxt is empty so abandoned
-    assert serder.ked["aid"] == 'BWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc'
+    assert serder.ked["pre"] == 'BWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc'
     assert serder.ked["nxt"] == ""
-    assert serder.raw == (b'{"vs":"KERI10JSON0000cf_","aid":"BWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhc'
+    assert serder.raw == (b'{"vs":"KERI10JSON0000cf_","pre":"BWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhc'
                           b'c","sn":"0","ilk":"icp","sith":"1","keys":["BWzwEHHzq7K0gzQPYGGwTmuupUhPx5_y'
                           b'Z-Wk1x4ejhcc"],"nxt":"","toad":"0","wits":[],"cnfg":[]}')
 
@@ -83,9 +83,9 @@ def test_keyeventfuncs():
     assert signer0.verfer.code == CryOneDex.Ed25519
     keys0 = [signer0.verfer.qb64]
     serder = incept(keys=keys0)  #  default nxt is empty so abandoned
-    assert serder.ked["aid"] == 'DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc'
+    assert serder.ked["pre"] == 'DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc'
     assert serder.ked["nxt"] == ""
-    assert serder.raw == (b'{"vs":"KERI10JSON0000cf_","aid":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhc'
+    assert serder.raw == (b'{"vs":"KERI10JSON0000cf_","pre":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhc'
                           b'c","sn":"0","ilk":"icp","sith":"1","keys":["DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_y'
                           b'Z-Wk1x4ejhcc"],"nxt":"","toad":"0","wits":[],"cnfg":[]}')
 
@@ -104,15 +104,15 @@ def test_keyeventfuncs():
     nxt1 = nexter1.qb64  # transferable so nxt is not empty
     assert nxt1 == 'ERoAnIgbnFekiKsGwQFaPub2lnB6GU4I80702IKn4aPs'
     serder0 = incept(keys=keys0, nxt=nxt1)
-    aid = serder0.ked["aid"]
-    assert serder0.ked["aid"] == 'DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc'
+    pre = serder0.ked["pre"]
+    assert serder0.ked["pre"] == 'DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc'
     assert serder0.ked["sn"] == '0'
     assert serder0.ked["nxt"] == nxt1
-    assert serder0.raw == (b'{"vs":"KERI10JSON0000fb_","aid":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhc'
+    assert serder0.raw == (b'{"vs":"KERI10JSON0000fb_","pre":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhc'
                            b'c","sn":"0","ilk":"icp","sith":"1","keys":["DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_y'
                            b'Z-Wk1x4ejhcc"],"nxt":"ERoAnIgbnFekiKsGwQFaPub2lnB6GU4I80702IKn4aPs","toad":"'
                            b'0","wits":[],"cnfg":[]}')
-    assert serder0.dig == 'Ec1jq8Lj3vwpmbfN4t6rrtSY7XpLdtz8oQwtVLt8Rj7M'
+    assert serder0.dig == 'Ey9BZP-aPB4DHtTDO7EJ1mRQok8S1J8henElY-lLnTOs'
 
 
     # Rotation: Transferable not abandoned i.e. next not empty
@@ -128,24 +128,24 @@ def test_keyeventfuncs():
     assert nexter2.sith == '1'  # default from keys
     nxt2 = nexter2.qb64  # transferable so nxt is not empty
     assert nxt2 == 'ECeM2JsaL9-ljwnIlsEYoPUJCv8zWcIeWmPSl2G14OP0'
-    serder1 = rotate(aid=aid, keys=keys1, dig=serder0.dig, nxt=nxt2, sn=1)
-    assert serder1.ked["aid"] == aid
+    serder1 = rotate(pre=pre, keys=keys1, dig=serder0.dig, nxt=nxt2, sn=1)
+    assert serder1.ked["pre"] == pre
     assert serder1.ked["sn"] == '1'
     assert serder1.ked["nxt"] == nxt2
     assert serder1.ked["dig"] == serder0.dig
-    assert serder1.raw == (b'{"vs":"KERI10JSON00013a_","aid":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhc'
-                           b'c","sn":"1","ilk":"rot","dig":"Ec1jq8Lj3vwpmbfN4t6rrtSY7XpLdtz8oQwtVLt8Rj7M"'
+    assert serder1.raw == (b'{"vs":"KERI10JSON00013a_","pre":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhc'
+                           b'c","sn":"1","ilk":"rot","dig":"Ey9BZP-aPB4DHtTDO7EJ1mRQok8S1J8henElY-lLnTOs"'
                            b',"sith":"1","keys":["DHgZa-u7veNZkqk2AxCnxrINGKfQ0bRiaf9FdA_-_49A"],"nxt":"E'
                            b'CeM2JsaL9-ljwnIlsEYoPUJCv8zWcIeWmPSl2G14OP0","toad":"0","cuts":[],"adds":[],'
                            b'"data":[]}')
 
     # Interaction:
-    serder2 = interact(aid=aid, dig=serder1.dig, sn=2)
-    assert serder2.ked["aid"] == aid
+    serder2 = interact(pre=pre, dig=serder1.dig, sn=2)
+    assert serder2.ked["pre"] == pre
     assert serder2.ked["sn"] == '2'
     assert serder2.ked["dig"] == serder1.dig
-    assert serder2.raw == (b'{"vs":"KERI10JSON0000a3_","aid":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhc'
-                           b'c","sn":"2","ilk":"ixn","dig":"E6uPKdq0fuah7wctnRX26SjHCkM_tZ_vUQ59UtrSEeuY"'
+    assert serder2.raw == (b'{"vs":"KERI10JSON0000a3_","pre":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhc'
+                           b'c","sn":"2","ilk":"ixn","dig":"EJj1B3VAcS74VBDlJeCWWOYX5X1h0n_I1gtgzcViGPCk"'
                            b',"data":[]}')
 
 
@@ -185,7 +185,7 @@ def test_kever():
     nsigs = 1  #  one attached signature unspecified index
 
     ked0 = dict(vs=Versify(kind=Serials.json, size=0),
-                aid="",  # qual base 64 prefix
+                pre="",  # qual base 64 prefix
                 sn="{:x}".format(sn),  # hex string no leading zeros lowercase
                 ilk=Ilks.icp,
                 sith="{:x}".format(sith), # hex string no leading zeros lowercase
@@ -202,8 +202,8 @@ def test_kever():
     assert aid0.code == CryOneDex.Ed25519
     assert aid0.qb64 == skp0.verfer.qb64
 
-    # update ked with aid
-    ked0["aid"] = aid0.qb64
+    # update ked with pre
+    ked0["pre"] = aid0.qb64
 
     # Serialize ked0
     tser0 = Serder(ked=ked0)
@@ -273,20 +273,20 @@ def test_keyeventsequence_0():
     nxt1 = nexter1.qb64  # transferable so nxt is not empty
     assert nxt1 == 'EGAPkzNZMtX-QiVgbRbyAIZGoXvbGv9IPb0foWTZvI_4'
     serder0 = incept(keys=keys0, nxt=nxt1)
-    aid = serder0.ked["aid"]
-    assert serder0.ked["aid"] == 'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA'
+    pre = serder0.ked["pre"]
+    assert serder0.ked["pre"] == 'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA'
     assert serder0.ked["sn"] == '0'
     assert serder0.ked["sith"] == '1'
     assert serder0.ked["keys"] == keys0
     assert serder0.ked["nxt"] == nxt1
-    assert serder0.dig == 'EyH1dHvVcntw1w-sQoIwrSN7DA0hfS8yQhz0H7u-gsmc'
+    assert serder0.dig == 'EgCvROg0cKXF_u_K0WH33PPB77bjZpIlgLy99xmYrHlM'
 
     # sign serialization and verify signature
     sig0 = signers[0].sign(serder0.raw, index=0)
     assert signers[0].verfer.verify(sig0.raw, serder0.raw)
     # create key event verifier state
     kever = Kever(serder=serder0, sigers=[sig0])
-    assert kever.prefixer.qb64 == aid
+    assert kever.prefixer.qb64 == pre
     assert kever.sn == 0
     assert kever.diger.qb64 == serder0.dig
     assert kever.ilk == Ilks.icp
@@ -303,8 +303,8 @@ def test_keyeventsequence_0():
     assert nexter2.sith == '1'
     nxt2 = nexter2.qb64  # transferable so nxt is not empty
     assert nxt2 == 'EoWDoTGQZ6lJ19LsaV4g42k5gccsB_-ttYHOft6kuYZk'
-    serder1 = rotate(aid=aid, keys=keys1, dig=serder0.dig, nxt=nxt2, sn=1)
-    assert serder1.ked["aid"] == aid
+    serder1 = rotate(pre=pre, keys=keys1, dig=serder0.dig, nxt=nxt2, sn=1)
+    assert serder1.ked["pre"] == pre
     assert serder1.ked["sn"] == '1'
     assert serder1.ked["sith"] == '1'
     assert serder1.ked["keys"] == keys1
@@ -316,7 +316,7 @@ def test_keyeventsequence_0():
     assert signers[1].verfer.verify(sig1.raw, serder1.raw)
     # update key event verifier state
     kever.update(serder=serder1, sigers=[sig1])
-    assert kever.prefixer.qb64 == aid
+    assert kever.prefixer.qb64 == pre
     assert kever.sn == 1
     assert kever.diger.qb64 == serder1.dig
     assert kever.ilk == Ilks.rot
@@ -328,8 +328,8 @@ def test_keyeventsequence_0():
     keys3 = [signers[3].verfer.qb64]
     nexter3 = Nexter(keys=keys3)
     nxt3 = nexter3.qb64  # transferable so nxt is not empty
-    serder2 = rotate(aid=aid, keys=keys2, dig=serder1.dig, nxt=nxt3, sn=2)
-    assert serder2.ked["aid"] == aid
+    serder2 = rotate(pre=pre, keys=keys2, dig=serder1.dig, nxt=nxt3, sn=2)
+    assert serder2.ked["pre"] == pre
     assert serder2.ked["sn"] == '2'
     assert serder2.ked["keys"] == keys2
     assert serder2.ked["nxt"] == nxt3
@@ -340,7 +340,7 @@ def test_keyeventsequence_0():
     assert signers[2].verfer.verify(sig2.raw, serder2.raw)
     # update key event verifier state
     kever.update(serder=serder2, sigers=[sig2])
-    assert kever.prefixer.qb64 == aid
+    assert kever.prefixer.qb64 == pre
     assert kever.sn == 2
     assert kever.diger.qb64 == serder2.dig
     assert kever.ilk == Ilks.rot
@@ -348,8 +348,8 @@ def test_keyeventsequence_0():
     assert kever.nexter.qb64 == nxt3
 
     # Event 3 Interaction
-    serder3 = interact(aid=aid, dig=serder2.dig, sn=3)
-    assert serder3.ked["aid"] == aid
+    serder3 = interact(pre=pre, dig=serder2.dig, sn=3)
+    assert serder3.ked["pre"] == pre
     assert serder3.ked["sn"] == '3'
     assert serder3.ked["dig"] == serder2.dig
 
@@ -358,7 +358,7 @@ def test_keyeventsequence_0():
     assert signers[2].verfer.verify(sig3.raw, serder3.raw)
     # update key event verifier state
     kever.update(serder=serder3, sigers=[sig3])
-    assert kever.prefixer.qb64 == aid
+    assert kever.prefixer.qb64 == pre
     assert kever.sn == 3
     assert kever.diger.qb64 == serder3.dig
     assert kever.ilk == Ilks.ixn
@@ -366,8 +366,8 @@ def test_keyeventsequence_0():
     assert kever.nexter.qb64 == nxt3  # no change
 
     # Event 4 Interaction
-    serder4 = interact(aid=aid, dig=serder3.dig, sn=4)
-    assert serder4.ked["aid"] == aid
+    serder4 = interact(pre=pre, dig=serder3.dig, sn=4)
+    assert serder4.ked["pre"] == pre
     assert serder4.ked["sn"] == '4'
     assert serder4.ked["dig"] == serder3.dig
 
@@ -376,7 +376,7 @@ def test_keyeventsequence_0():
     assert signers[2].verfer.verify(sig4.raw, serder4.raw)
     # update key event verifier state
     kever.update(serder=serder4, sigers=[sig4])
-    assert kever.prefixer.qb64 == aid
+    assert kever.prefixer.qb64 == pre
     assert kever.sn == 4
     assert kever.diger.qb64 == serder4.dig
     assert kever.ilk == Ilks.ixn
@@ -388,8 +388,8 @@ def test_keyeventsequence_0():
     keys4 = [signers[4].verfer.qb64]
     nexter4 = Nexter(keys=keys4)
     nxt4 = nexter4.qb64  # transferable so nxt is not empty
-    serder5 = rotate(aid=aid, keys=keys3, dig=serder4.dig, nxt=nxt4, sn=5)
-    assert serder5.ked["aid"] == aid
+    serder5 = rotate(pre=pre, keys=keys3, dig=serder4.dig, nxt=nxt4, sn=5)
+    assert serder5.ked["pre"] == pre
     assert serder5.ked["sn"] == '5'
     assert serder5.ked["keys"] == keys3
     assert serder5.ked["nxt"] == nxt4
@@ -400,7 +400,7 @@ def test_keyeventsequence_0():
     assert signers[3].verfer.verify(sig5.raw, serder5.raw)
     # update key event verifier state
     kever.update(serder=serder5, sigers=[sig5])
-    assert kever.prefixer.qb64 == aid
+    assert kever.prefixer.qb64 == pre
     assert kever.sn == 5
     assert kever.diger.qb64 == serder5.dig
     assert kever.ilk == Ilks.rot
@@ -408,8 +408,8 @@ def test_keyeventsequence_0():
     assert kever.nexter.qb64 == nxt4
 
     # Event 6 Interaction
-    serder6 = interact(aid=aid, dig=serder5.dig, sn=6)
-    assert serder6.ked["aid"] == aid
+    serder6 = interact(pre=pre, dig=serder5.dig, sn=6)
+    assert serder6.ked["pre"] == pre
     assert serder6.ked["sn"] == '6'
     assert serder6.ked["dig"] == serder5.dig
 
@@ -418,7 +418,7 @@ def test_keyeventsequence_0():
     assert signers[3].verfer.verify(sig6.raw, serder6.raw)
     # update key event verifier state
     kever.update(serder=serder6, sigers=[sig6])
-    assert kever.prefixer.qb64 == aid
+    assert kever.prefixer.qb64 == pre
     assert kever.sn == 6
     assert kever.diger.qb64 == serder6.dig
     assert kever.ilk == Ilks.ixn
@@ -427,8 +427,8 @@ def test_keyeventsequence_0():
 
     # Event 7 Rotation to null NonTransferable Abandon
     nxt5 = ""  # nxt digest is empty
-    serder7 = rotate(aid=aid, keys=keys4, dig=serder6.dig, nxt=nxt5, sn=7)
-    assert serder7.ked["aid"] == aid
+    serder7 = rotate(pre=pre, keys=keys4, dig=serder6.dig, nxt=nxt5, sn=7)
+    assert serder7.ked["pre"] == pre
     assert serder7.ked["sn"] == '7'
     assert serder7.ked["keys"] == keys4
     assert serder7.ked["nxt"] == nxt5
@@ -439,7 +439,7 @@ def test_keyeventsequence_0():
     assert signers[4].verfer.verify(sig7.raw, serder7.raw)
     # update key event verifier state
     kever.update(serder=serder7, sigers=[sig7])
-    assert kever.prefixer.qb64 == aid
+    assert kever.prefixer.qb64 == pre
     assert kever.sn == 7
     assert kever.diger.qb64 == serder7.dig
     assert kever.ilk == Ilks.rot
@@ -448,8 +448,8 @@ def test_keyeventsequence_0():
     assert kever.nonTrans
 
     # Event 8 Interaction
-    serder8 = interact(aid=aid, dig=serder7.dig, sn=8)
-    assert serder8.ked["aid"] == aid
+    serder8 = interact(pre=pre, dig=serder7.dig, sn=8)
+    assert serder8.ked["pre"] == pre
     assert serder8.ked["sn"] == '8'
     assert serder8.ked["dig"] == serder7.dig
 
@@ -464,8 +464,8 @@ def test_keyeventsequence_0():
     keys5 = [signers[5].verfer.qb64]
     nexter5 = Nexter(keys=keys5)
     nxt5 = nexter4.qb64  # transferable so nxt is not empty
-    serder8 = rotate(aid=aid, keys=keys5, dig=serder7.dig, nxt=nxt5, sn=8)
-    assert serder8.ked["aid"] == aid
+    serder8 = rotate(pre=pre, keys=keys5, dig=serder7.dig, nxt=nxt5, sn=8)
+    assert serder8.ked["pre"] == pre
     assert serder8.ked["sn"] == '8'
     assert serder8.ked["dig"] == serder7.dig
 
@@ -522,8 +522,8 @@ def test_keyeventsequence_1():
     nxt1 = nexter1.qb64  # transferable so nxt is not empty
     cnfg = [dict(trait=TraitDex.EstOnly)]
     serder0 = incept(keys=keys0, nxt=nxt1, cnfg=cnfg)
-    aid = serder0.ked["aid"]
-    assert serder0.ked["aid"] == 'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA'
+    pre = serder0.ked["pre"]
+    assert serder0.ked["pre"] == 'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA'
     assert serder0.ked["sn"] == '0'
     assert serder0.ked["sith"] == '1'
     assert serder0.ked["keys"] == keys0
@@ -534,7 +534,7 @@ def test_keyeventsequence_1():
     assert signers[0].verfer.verify(sig0.raw, serder0.raw)
     # create key event verifier state
     kever = Kever(serder=serder0, sigers=[sig0])
-    assert kever.prefixer.qb64 == aid
+    assert kever.prefixer.qb64 == pre
     assert kever.sn == 0
     assert kever.diger.qb64 == serder0.dig
     assert kever.ilk == Ilks.icp
@@ -545,8 +545,8 @@ def test_keyeventsequence_1():
     assert kever.nonTrans == False
 
     # Event 1 Interaction
-    serder1 = interact(aid=aid, dig=serder0.dig, sn=1)
-    assert serder1.ked["aid"] == aid
+    serder1 = interact(pre=pre, dig=serder0.dig, sn=1)
+    assert serder1.ked["pre"] == pre
     assert serder1.ked["sn"] == '1'
     assert serder1.ked["dig"] == serder0.dig
     # sign serialization and verify signature
@@ -564,8 +564,8 @@ def test_keyeventsequence_1():
     assert nexter2.sith == '1'
     nxt2 = nexter2.qb64  # transferable so nxt is not empty
     assert nxt2 == 'EoWDoTGQZ6lJ19LsaV4g42k5gccsB_-ttYHOft6kuYZk'
-    serder1 = rotate(aid=aid, keys=keys1, dig=serder0.dig, nxt=nxt2, sn=1)
-    assert serder1.ked["aid"] == aid
+    serder1 = rotate(pre=pre, keys=keys1, dig=serder0.dig, nxt=nxt2, sn=1)
+    assert serder1.ked["pre"] == pre
     assert serder1.ked["sn"] == '1'
     assert serder1.ked["sith"] == '1'
     assert serder1.ked["keys"] == keys1
@@ -577,7 +577,7 @@ def test_keyeventsequence_1():
     assert signers[1].verfer.verify(sig1.raw, serder1.raw)
     # update key event verifier state
     kever.update(serder=serder1, sigers=[sig1])
-    assert kever.prefixer.qb64 == aid
+    assert kever.prefixer.qb64 == pre
     assert kever.sn == 1
     assert kever.diger.qb64 == serder1.dig
     assert kever.ilk == Ilks.rot
@@ -626,15 +626,15 @@ def test_kevery():
     kes.extend(counter.qb64b)
     kes.extend(siger.qb64b)
 
-    assert kes == bytearray(b'{"vs":"KERI10JSON0000fb_","aid":"DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_'
+    assert kes == bytearray(b'{"vs":"KERI10JSON0000fb_","pre":"DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_'
                             b'ZOoeKtWTOunRA","sn":"0","ilk":"icp","sith":"1","keys":["DSuhyBcP'
                             b'ZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"nxt":"EGAPkzNZMtX-QiVgbR'
                             b'byAIZGoXvbGv9IPb0foWTZvI_4","toad":"0","wits":[],"cnfg":[]}-AABA'
-                            b'A8yMYsLXbmnwXWIsdZ7Uzw3Q7ppynI1xYCf-43hsf7XIgp5NZ-HlZbDC3o0lwWEF'
-                            b'nk4O6glvxx3bJ8Zfgg606DA')
+                            b'APcgkk6etAU3B-0zPX1ctRg0V2Bz26zH9yfOHiHyH46XF8gQWNkpcaPOSn9oZGJU'
+                            b'm0TZI-P_uEjcIN-Wu98YeAw')
 
     # Event 1 Rotation Transferable
-    serder = rotate(aid=kever.prefixer.qb64,
+    serder = rotate(pre=kever.prefixer.qb64,
                     keys=[signers[1].verfer.qb64],
                     dig=kever.diger.qb64,
                     nxt=Nexter(keys=[signers[2].verfer.qb64]).qb64,
@@ -651,7 +651,7 @@ def test_kevery():
     kes.extend(siger.qb64b)
 
     # Event 2 Rotation Transferable
-    serder = rotate(aid=kever.prefixer.qb64,
+    serder = rotate(pre=kever.prefixer.qb64,
                     keys=[signers[2].verfer.qb64],
                     dig=kever.diger.qb64,
                     nxt=Nexter(keys=[signers[3].verfer.qb64]).qb64,
@@ -668,7 +668,7 @@ def test_kevery():
     kes.extend(siger.qb64b)
 
     # Event 3 Interaction
-    serder = interact(aid=kever.prefixer.qb64,
+    serder = interact(pre=kever.prefixer.qb64,
                       dig=kever.diger.qb64,
                       sn=3)
     # create sig counter
@@ -683,7 +683,7 @@ def test_kevery():
     kes.extend(siger.qb64b)
 
     # Event 4 Interaction
-    serder = interact(aid=kever.prefixer.qb64,
+    serder = interact(pre=kever.prefixer.qb64,
                       dig=kever.diger.qb64,
                       sn=4)
     # create sig counter
@@ -698,7 +698,7 @@ def test_kevery():
     kes.extend(siger.qb64b)
 
     # Event 5 Rotation Transferable
-    serder = rotate(aid=kever.prefixer.qb64,
+    serder = rotate(pre=kever.prefixer.qb64,
                     keys=[signers[3].verfer.qb64],
                     dig=kever.diger.qb64,
                     nxt=Nexter(keys=[signers[4].verfer.qb64]).qb64,
@@ -715,7 +715,7 @@ def test_kevery():
     kes.extend(siger.qb64b)
 
     # Event 6 Interaction
-    serder = interact(aid=kever.prefixer.qb64,
+    serder = interact(pre=kever.prefixer.qb64,
                       dig=kever.diger.qb64,
                       sn=6)
     # create sig counter
@@ -731,7 +731,7 @@ def test_kevery():
 
     # Event 7 Rotation to null NonTransferable Abandon
    # nxt digest is empty
-    serder = rotate(aid=kever.prefixer.qb64,
+    serder = rotate(pre=kever.prefixer.qb64,
                 keys=[signers[4].verfer.qb64],
                 dig=kever.diger.qb64,
                 nxt="",
@@ -748,7 +748,7 @@ def test_kevery():
     kes.extend(siger.qb64b)
 
     # Event 8 Interaction
-    serder = interact(aid=kever.prefixer.qb64,
+    serder = interact(pre=kever.prefixer.qb64,
                       dig=kever.diger.qb64,
                       sn=8)
     # create sig counter
@@ -764,7 +764,7 @@ def test_kevery():
     kes.extend(siger.qb64b)
 
     # Event 8 Rotation
-    serder = rotate(aid=kever.prefixer.qb64,
+    serder = rotate(pre=kever.prefixer.qb64,
                     keys=[signers[4].verfer.qb64],
                     dig=kever.diger.qb64,
                     nxt=Nexter(keys=[signers[5].verfer.qb64]).qb64,
@@ -788,9 +788,9 @@ def test_kevery():
     kevery = Kevery(logs=klogs)
     kevery.processAll(kes=kes)
 
-    aid = kever.prefixer.qb64
-    assert aid in klogs.kevers
-    vkever = klogs.kevers[aid]
+    pre = kever.prefixer.qb64
+    assert pre in klogs.kevers
+    vkever = klogs.kevers[pre]
     assert vkever.sn == kever.sn
     assert vkever.verfers[0].qb64 == kever.verfers[0].qb64
     assert vkever.verfers[0].qb64 == signers[4].verfer.qb64
@@ -800,7 +800,7 @@ def test_kevery():
 
 def test_multisig_digaid():
     """
-    Test multisig with self-addressing (digest) aid
+    Test multisig with self-addressing (digest) pre
     """
 
 
@@ -835,7 +835,7 @@ def test_multisig_digaid():
                     sith=sith,
                     nxt=Nexter(keys=nxtkeys).qb64)
 
-    assert serder.ked["aid"] == 'EeHEtwqUsoOHqchJNDvxIb-bTOB4E8m73osS_cJYuShY'
+    assert serder.ked["pre"] == 'EeHEtwqUsoOHqchJNDvxIb-bTOB4E8m73osS_cJYuShY'
     # create sig counter
     count = len(keys)
     counter = SigCounter(count=count)  # default is count = 1
@@ -849,22 +849,22 @@ def test_multisig_digaid():
     for siger in sigers:
         kes.extend(siger.qb64b)
 
-    assert kes == bytearray(b'{"vs":"KERI10JSON000159_","aid":"EeHEtwqUsoOHqchJNDvxIb-bTOB4E8m'
+    assert kes == bytearray(b'{"vs":"KERI10JSON000159_","pre":"EeHEtwqUsoOHqchJNDvxIb-bTOB4E8m'
                             b'73osS_cJYuShY","sn":"0","ilk":"icp","sith":"2","keys":["DSuhyBcP'
                             b'ZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA","DVcuJOOJF1IE8svqEtrSuyQjG'
                             b'Td2HhfAkt9y2QkUtFJI","DT1iAhBWCkvChxNWsby2J0pJyxBIxbAtbLA0Ljx-Gr'
                             b'h8"],"nxt":"Evhf3437ZRRnVhT0zOxo_rBX_GxpGoAnLuzrVlDK8ZdM","toad"'
-                            b':"0","wits":[],"cnfg":[]}-AADAADbqDL-TEeWCTLQlMx4D09-u7amN9_vsSb'
-                            b'-qe50GU3EaXMDhuasopDf4B4Kei6EdkEGRHSYzWXOOBlarS5tfFAwAB3BGAHcoGt'
-                            b'DsoFkbnxbekxnfcXhfCooQyHN30_k8xadUQRLt6Rzj5u30vqzRVhRCYTyl_OLFBI'
-                            b'q7JlDDhyheXBgACzAUaBxz31x0q5BsDZpCSIJHnH-HsFCocsKFD6JjhpgcR9ECel'
-                            b'H2iJPk8WQPXjqZ9ROqUV6b0_uKU_RjRdqMnAg')
+                            b':"0","wits":[],"cnfg":[]}-AADAA64PoFOk7OFJyDwa3QvxuObP2NFa4lPPVx'
+                            b'FH6Nw5G4ypKpce4SjQ3y5XrkVjGJmSqt8lZPWDfipBg1nbo6iGZBgAB1szAmkNiH'
+                            b'NjBBB4XitB4gW8PLYsrSXYmLhQ5rQ74pwNuZlJBz3SLtds8nsA6gIrNGscnC0k24'
+                            b'BT17gfJjJcnCwACgHLdsMXS57XzQRDP-R2MBEVjOzkMyqtdT0TmRVj3qHv8tVd2T'
+                            b'3VYw19Ly0KovWiiqZTeQkI8JSXanfJKGw0_Bg')
 
     # Event 1 Rotation Transferable
     keys = nxtkeys
     sith = 2
     nxtkeys = [signers[5].verfer.qb64, signers[6].verfer.qb64, signers[7].verfer.qb64]
-    serder = rotate(aid=kever.prefixer.qb64,
+    serder = rotate(pre=kever.prefixer.qb64,
                     keys=keys,
                     sith=sith,
                     dig=kever.diger.qb64,
@@ -885,7 +885,7 @@ def test_multisig_digaid():
 
 
     # Event 2 Interaction
-    serder = interact(aid=kever.prefixer.qb64,
+    serder = interact(pre=kever.prefixer.qb64,
                       dig=kever.diger.qb64,
                       sn=2)
     # create sig counter
@@ -901,7 +901,7 @@ def test_multisig_digaid():
         kes.extend(siger.qb64b)
 
     # Event 4 Interaction
-    serder = interact(aid=kever.prefixer.qb64,
+    serder = interact(pre=kever.prefixer.qb64,
                       dig=kever.diger.qb64,
                       sn=3)
     # create sig counter
@@ -919,7 +919,7 @@ def test_multisig_digaid():
     # Event 7 Rotation to null NonTransferable Abandon
     # nxt digest is empty
     keys = nxtkeys
-    serder = rotate(aid=kever.prefixer.qb64,
+    serder = rotate(pre=kever.prefixer.qb64,
                 keys=keys,
                 sith=2,
                 dig=kever.diger.qb64,
@@ -945,9 +945,9 @@ def test_multisig_digaid():
     kevery = Kevery(logs=klogs)
     kevery.processAll(kes=kes)
 
-    aid = kever.prefixer.qb64
-    assert aid in klogs.kevers
-    vkever = klogs.kevers[aid]
+    pre = kever.prefixer.qb64
+    assert pre in klogs.kevers
+    vkever = klogs.kevers[pre]
     assert vkever.sn == kever.sn
     assert vkever.verfers[0].qb64 == kever.verfers[0].qb64
     assert vkever.verfers[0].qb64 == signers[5].verfer.qb64
@@ -978,7 +978,7 @@ def test_process_nontransferable():
     nsigs = 1  #  one attached signature unspecified index
 
     ked0 = dict(vs=Versify(kind=Serials.json, size=0),
-                aid=aid0.qb64,  # qual base 64 prefix
+                pre=aid0.qb64,  # qual base 64 prefix
                 sn="{:x}".format(sn),  # hex string no leading zeros lowercase
                 ilk=Ilks.icp,
                 sith="{:x}".format(sith), # hex string no leading zeros lowercase
@@ -1029,8 +1029,8 @@ def test_process_nontransferable():
         assert verfer.verify(rsig.raw, rser0.raw)
         del msgb0[:len(rsig.qb64)]
 
-    # verify aid
-    raid0 = Prefixer(qb64=rser0.ked["aid"])
+    # verify pre
+    raid0 = Prefixer(qb64=rser0.ked["pre"])
     assert raid0.verify(ked=rser0.ked)
     """ Done Test """
 
@@ -1062,7 +1062,7 @@ def test_process_transferable():
     nsigs = 1  #  one attached signature unspecified index
 
     ked0 = dict(vs=Versify(kind=Serials.json, size=0),
-                aid="",  # qual base 64 prefix
+                pre="",  # qual base 64 prefix
                 sn="{:x}".format(sn),  # hex string no leading zeros lowercase
                 ilk=Ilks.icp,
                 sith="{:x}".format(sith), # hex string no leading zeros lowercase
@@ -1078,8 +1078,8 @@ def test_process_transferable():
     assert aid0.code == CryOneDex.Ed25519
     assert aid0.qb64 == skp0.verfer.qb64
 
-    # update ked with aid
-    ked0["aid"] = aid0.qb64
+    # update ked with pre
+    ked0["pre"] = aid0.qb64
 
     # Serialize ked0
     tser0 = Serder(ked=ked0)
@@ -1118,8 +1118,8 @@ def test_process_transferable():
         assert verfer.verify(rsig.raw, rser0.raw)
         del msgb0[:len(rsig.qb64)]
 
-    # verify aid
-    raid0 = Prefixer(qb64=rser0.ked["aid"])
+    # verify pre
+    raid0 = Prefixer(qb64=rser0.ked["pre"])
     assert raid0.verify(ked=rser0.ked)
 
     #verify nxt digest from event is still valid
@@ -1133,7 +1133,7 @@ def test_process_manual():
     """
     Test manual process of generating and validating inception key event message
     """
-    # create qualified aid in basic format
+    # create qualified pre in basic format
     # workflow is start with seed and save seed. Seed in this case is 32 bytes
     # aidseed = pysodium.randombytes(pysodium.crypto_sign_SEEDBYTES)
     aidseed = b'p6\xac\xb7\x10R\xc4\x9c7\xe8\x97\xa3\xdb!Z\x08\xdf\xfaR\x07\x9a\xb3\x1e\x9d\xda\xee\xa2\xbc\xe4;w\xae'
@@ -1146,7 +1146,7 @@ def test_process_manual():
     assert verkey == b'\xaf\x96\xb0p\xfb0\xa7\xd0\xa4\x18\xc9\xdc\x1d\x86\xc2:\x98\xf7?t\x1b\xde.\xcc\xcb;\x8a\xb0\xa2O\xe7K'
     assert len(verkey) == 32
 
-    # create qualified aid in basic format
+    # create qualified pre in basic format
     aidmat = CryMat(raw=verkey, code=CryOneDex.Ed25519)
     assert aidmat.qb64 == 'Dr5awcPswp9CkGMncHYbCOpj3P3Qb3i7MyzuKsKJP50s'
 
@@ -1187,7 +1187,7 @@ def test_process_manual():
 
     #create key event dict
     ked0 = dict(vs=Versify(kind=Serials.json, size=0),
-                aid=aidmat.qb64,  # qual base 64 prefix
+                pre=aidmat.qb64,  # qual base 64 prefix
                 sn="{:x}".format(sn),  # hex string no leading zeros lowercase
                 ilk=Ilks.icp,
                 sith="{:x}".format(sith), # hex string no leading zeros lowercase
@@ -1200,7 +1200,7 @@ def test_process_manual():
 
 
     txsrdr = Serder(ked=ked0, kind=Serials.json)
-    assert txsrdr.raw == (b'{"vs":"KERI10JSON0000fb_","aid":"Dr5awcPswp9CkGMncHYbCOpj3P3Qb3i7MyzuKsKJP50'
+    assert txsrdr.raw == (b'{"vs":"KERI10JSON0000fb_","pre":"Dr5awcPswp9CkGMncHYbCOpj3P3Qb3i7MyzuKsKJP50'
                           b's","sn":"0","ilk":"icp","sith":"1","keys":["Dr5awcPswp9CkGMncHYbCOpj3P3Qb3i7'
                           b'MyzuKsKJP50s"],"nxt":"E3ld50z3LYM7pmQxG3bJDNgOnRg1T1v5tmYmsYDyqiNI","toad":"'
                           b'0","wits":[],"cnfg":[]}')
@@ -1209,7 +1209,7 @@ def test_process_manual():
 
     txdig = blake3.blake3(txsrdr.raw).digest()
     txdigmat = CryMat(raw=txdig, code=CryOneDex.Blake3_256)
-    assert txdigmat.qb64 == 'E2LTcl4MKQfXUu7hYG-KGnQKjCBA4rYDwLBROIX8pyK8'
+    assert txdigmat.qb64 == 'EdZaosuU8YMf2LUnjr6HEjDqeuP42SeiIC4OIGl9pF_k'
 
     assert txsrdr.dig == txdigmat.qb64
 
@@ -1220,7 +1220,7 @@ def test_process_manual():
     assert not result  # None if verifies successfully else raises ValueError
 
     txsigmat = SigMat(raw=sig0raw, code=SigTwoDex.Ed25519, index=index)
-    assert txsigmat.qb64 == 'AAYz-F6RJVhqXkRMWdxV12fzZmSqBeMrYDBrutQKEDFQW1TnNn8ftcSnm6pVamB7xm90aCAr3VzJAyidV-t8JaDw'
+    assert txsigmat.qb64 == 'AAz1KAV2z5IRqcFe4gPs9l3wsFKi1NsSZvBe8yQJmiu5AzJ91Timrykocna6Z_pQBl2gt59I_F6BsSwFbIOG1TDQ'
     assert len(txsigmat.qb64) == 88
     assert txsigmat.index == index
 
@@ -1238,7 +1238,7 @@ def test_process_manual():
     rxsigmat = SigMat(qb64=rxsigqb64)
     assert rxsigmat.index == index
 
-    rxaidqb64 = rxsrdr.ked["aid"]
+    rxaidqb64 = rxsrdr.ked["pre"]
     rxaidmat = CryMat(qb64=rxaidqb64)
     assert rxaidmat.qb64 == aidmat.qb64
     assert rxaidmat.code == CryOneDex.Ed25519

--- a/tests/help/test_helping.py
+++ b/tests/help/test_helping.py
@@ -62,7 +62,7 @@ def test_extractvalues():
     """
     Test function extractValues
     """
-    (b'{"vs":"KERI10JSON0000fb_","aid":"DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_'
+    (b'{"vs":"KERI10JSON0000fb_","pre":"DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_'
                                 b'ZOoeKtWTOunRA","sn":"0","ilk":"icp","sith":"1","keys":["DSuhyBcP'
                                 b'ZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"nxt":"EGAPkzNZMtX-QiVgbR'
                                 b'byAIZGoXvbGv9IPb0foWTZvI_4","toad":"0","wits":[],"cnfg":[]}-AABA'
@@ -70,7 +70,7 @@ def test_extractvalues():
                                 b'nk4O6glvxx3bJ8Zfgg606DA')
 
     ked = dict(vs="KERI10JSON0000fb_",
-               aid="DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA",
+               pre="DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA",
                sn="0",
                ilk="icp",
                sith="1",


### PR DESCRIPTION
In KERI the element in the event field is an autonomic identifier prefix not the full autonomic identifier (aid). This will become extremely confusing once we start using full aid or autonomic id not merely the unique cryptographic prefix. It was a bad idea to use id and then aid because this part of KERI is only concerned with the prefix but later KERI will include support for full aid in other parts of the code. 

