### PR TITLE
added vs back into extracted data. 

### DIFF
--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -836,11 +836,6 @@ class Nexter(Diger):
 
         return (self._verify(ser=ser, dig=self.raw))
 
-# elements in digest or signature derivation from inception icp
-ICP_DERIVE_LABELS = ["sith", "keys", "nxt", "toad", "wits", "cnfg"]
-# elements in digest or signature derivation from delegated inception dip
-DIP_DERIVE_LABELS = ["sith", "keys", "nxt", "toad", "wits", "perm", "seal"]
-
 
 class Prefixer(CryMat):
     """
@@ -858,9 +853,9 @@ class Prefixer(CryMat):
 
     """
     # elements in digest or signature derivation from inception icp
-    IcpLabels = ["sn", "ilk", "sith", "keys", "nxt", "toad", "wits", "cnfg"]
+    IcpLabels = ["vs", "sn", "ilk", "sith", "keys", "nxt", "toad", "wits", "cnfg"]
     # elements in digest or signature derivation from delegated inception dip
-    DipLabels = ["sn", "ilk", "sith", "keys", "nxt", "toad", "wits", "perm", "seal"]
+    DipLabels = ["vs", "sn", "ilk", "sith", "keys", "nxt", "toad", "wits", "perm", "seal"]
 
     def __init__(self, raw=None, code=CryOneDex.Ed25519N, ked=None,
                  seed=None, secret=None, **kwa):
@@ -990,6 +985,11 @@ class Prefixer(CryMat):
         else:
             raise DerivationError("Invalid ilk = {} to derive pre.".format(ilk))
 
+        # put in dummy pre to get size correct
+        ked["pre"] = "{}".format("a"*CryOneSizes[CryOneDex.Blake3_256])
+        serder = Serder(ked=ked)
+        ked = serder.ked  # use updated ked with valid vs element
+
         for l in labels:
             if l not in ked:
                 raise DerivationError("Missing element = {} from ked.".format(l))
@@ -1011,6 +1011,11 @@ class Prefixer(CryMat):
             labels = self.DipLabels  # DIP_DERIVE_LABELS
         else:
             raise DerivationError("Invalid ilk = {} to derive pre.".format(ilk))
+
+        # put in dummy pre to get size correct
+        ked["pre"] = "{}".format("a"*CryTwoSizes[CryTwoDex.Ed25519])
+        serder = Serder(ked=ked)
+        ked = serder.ked  # use updated ked with valid vs element
 
         for l in labels:
             if l not in ked:
@@ -1148,6 +1153,11 @@ class Prefixer(CryMat):
                 labels = self.DipLabels  # DIP_DERIVE_LABELS
             else:
                 raise DerivationError("Invalid ilk = {} to derive prefix.".format(ilk))
+
+            # put in dummy pre to get size correct
+            ked["pre"] = "{}".format("a"*CryTwoSizes[CryTwoDex.Ed25519])
+            serder = Serder(ked=ked)
+            ked = serder.ked  # use updated ked with valid vs element
 
             for l in labels:
                 if l not in ked:

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -625,7 +625,7 @@ def test_prefixer():
                )
 
     prefixer = Prefixer(ked=ked, code=CryOneDex.Blake3_256)
-    assert prefixer.qb64 == 'Eef0L-H343Eww3BnL0trkQhpxUGyT7AmsDFEEdQv4kPU'
+    assert prefixer.qb64 == 'EFMo3ix8YSCJn5mVK5TvL5A30V-eOXYKfEsqWRWoA6z4'
     assert prefixer.verify(ked=ked) == True
 
 
@@ -643,7 +643,7 @@ def test_prefixer():
                )
 
     prefixer = Prefixer(ked=ked, code=CryOneDex.Blake3_256)
-    assert prefixer.qb64 == 'EkbeB57LYWRYNqg4xarckyfd_LsaH0J350WmOdvMwU_Q'
+    assert prefixer.qb64 == 'EBv1R8a4iqdMsU7QmL0cRR9saFtAWPwP-yMRO532FxHo'
     assert prefixer.verify(ked=ked) == True
 
     perm = []
@@ -666,7 +666,7 @@ def test_prefixer():
                )
 
     prefixer = Prefixer(ked=ked, code=CryOneDex.Blake3_256)
-    assert prefixer.qb64 == 'EDjYdngSGQkPdtSgr1W0nb4arGq0pBeWjoY51zeoMzsw'
+    assert prefixer.qb64 == 'EzLLOofkapRBf7qbD835qX2ZGZJAOildwZTLfiVTIg04'
     assert prefixer.verify(ked=ked) == True
 
     #  Test signature derivation
@@ -702,11 +702,11 @@ def test_prefixer():
                )
 
     prefixer = Prefixer(ked=ked, code=CryTwoDex.Ed25519, seed=seed)
-    assert prefixer.qb64 == '0B3c4ueR9JwCpUqj11EbfuexY5InHBGiPT8bdsFwy0F9Z28nsRYjbVHqcQ5Ulo63xbU9m-sUnVOqh-29WmaJRLCA'
+    assert prefixer.qb64 == '0B0uVeeaCtXTAj04_27g5pSKjXouQaC1mHcWswzkL7Jk0XC0yTyNnIvhaXnSxGbzY8WaPv63iAfWhJ81MKACRuAQ'
     assert prefixer.verify(ked=ked) == True
 
     prefixer = Prefixer(ked=ked, code=CryTwoDex.Ed25519, secret=secret)
-    assert prefixer.qb64 == '0B3c4ueR9JwCpUqj11EbfuexY5InHBGiPT8bdsFwy0F9Z28nsRYjbVHqcQ5Ulo63xbU9m-sUnVOqh-29WmaJRLCA'
+    assert prefixer.qb64 == '0B0uVeeaCtXTAj04_27g5pSKjXouQaC1mHcWswzkL7Jk0XC0yTyNnIvhaXnSxGbzY8WaPv63iAfWhJ81MKACRuAQ'
     assert prefixer.verify(ked=ked) == True
 
     """ Done Test """

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -835,7 +835,7 @@ def test_multisig_digaid():
                     sith=sith,
                     nxt=Nexter(keys=nxtkeys).qb64)
 
-    assert serder.ked["pre"] == 'EsXOsQwsb0sM_fGWnoau5CdvjrvLj7YWinjeyTusmBnk'
+    assert serder.ked["pre"] == 'ECui-E44CqN2U7uffCikRCp_YKLkPrA4jsTZ_A0XRLzc'
     # create sig counter
     count = len(keys)
     counter = SigCounter(count=count)  # default is count = 1
@@ -849,16 +849,17 @@ def test_multisig_digaid():
     for siger in sigers:
         kes.extend(siger.qb64b)
 
-    assert kes == bytearray(b'{"vs":"KERI10JSON000159_","pre":"EsXOsQwsb0sM_fGWnoau5CdvjrvLj7Y'
-                            b'WinjeyTusmBnk","sn":"0","ilk":"icp","sith":"2","keys":["DSuhyBcP'
+    assert kes == bytearray(b'{"vs":"KERI10JSON000159_","pre":"ECui-E44CqN2U7uffCikRCp_YKLkPrA'
+                            b'4jsTZ_A0XRLzc","sn":"0","ilk":"icp","sith":"2","keys":["DSuhyBcP'
                             b'ZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA","DVcuJOOJF1IE8svqEtrSuyQjG'
                             b'Td2HhfAkt9y2QkUtFJI","DT1iAhBWCkvChxNWsby2J0pJyxBIxbAtbLA0Ljx-Gr'
                             b'h8"],"nxt":"Evhf3437ZRRnVhT0zOxo_rBX_GxpGoAnLuzrVlDK8ZdM","toad"'
-                            b':"0","wits":[],"cnfg":[]}-AADAA97g9QIKQb5c9N0msEp3rB0KN5Lxv31wPW'
-                            b'tPRknYBAr9SuzrdfRXRrJiG-4utXDLj-8HHMrJfk4rsMhxDkrgwDgAB8B8Gi-_ql'
-                            b'YQSXccPrcBmeKa-gfQeq3dVsNU3CGAnEZrhpKKUUuK6MJ7jvv8QCiCeEm0ONCaot'
-                            b'ZQl0u1k17mdBgAC_659hyxwtTMZy4Jxs0LERF0JQ8NpaVrz5xURR3BXIBBFSg6la'
-                            b'nso6kmpiRlavNVZlqTVz4YrsfI4b_LQ1CgYAQ')
+                            b':"0","wits":[],"cnfg":[]}-AADAAJ66nrRaNjltE31FZ4mELVGUMc_XOqOAOX'
+                            b'ZQjZCEAvbeJQ8r3AnccIe1aepMwgoQUeFdIIQLeEDcH8veLdud_DQABTQYtYWKh3'
+                            b'ScYij7MOZz3oA6ZXdIDLRrv0ObeSb4oc6LYrR1LfkICfXiYDnp90tAdvaJX5siCL'
+                            b'jSD3vfEM9ADDAACQTgUl4zF6U8hfDy8wwUva-HCAiS8LQuP7elKAHqgS8qtqv5hE'
+                            b'j3aTjwE91UtgAX2oCgaw98BCYSeT5AuY1SpDA')
+
 
     # Event 1 Rotation Transferable
     keys = nxtkeys


### PR DESCRIPTION
Had to modify derivation. So now there is only one inception event for a given version and serialization kind that will result in a self-addressing digest based identifier prefix