### PR TITLE
Added CryCounter class

### DIFF
--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -920,6 +920,17 @@ class Prefixer(CryMat):
         return (self._derive(ked=ked, seed=seed, secret=secret))
 
 
+    def verify(self, ked):
+        """
+        Returns True if derivation from iked for .code matches .qb64,
+                False otherwise
+
+        Parameters:
+            ked is inception key event dict
+        """
+        return (self._verify(ked=ked, pre=self.qb64))
+
+
     def _DeriveBasicEd25519N(self, ked, seed=None, secret=None):
         """
         Returns tuple (raw, code) of basic nontransferable Ed25519 prefix (qb64)
@@ -950,6 +961,32 @@ class Prefixer(CryMat):
         return (verfer.raw, verfer.code)
 
 
+    def _VerifyBasicEd25519N(self, ked, pre):
+        """
+        Returns True if verified raises exception otherwise
+        Verify derivation of fully qualified Base64 pre from inception iked dict
+
+        Parameters:
+            ked is inception key event dict
+            pre is Base64 fully qualified prefix
+        """
+        try:
+            keys = ked["keys"]
+            if len(keys) != 1:
+                return False
+
+            if keys[0] != pre:
+                return False
+
+            if ked["nxt"]:  # must be empty
+                return False
+
+        except Exception as ex:
+            return False
+
+        return True
+
+
     def _DeriveBasicEd25519(self, ked, seed=None, secret=None):
         """
         Returns tuple (raw, code) of basic Ed25519 prefix (qb64)
@@ -970,6 +1007,29 @@ class Prefixer(CryMat):
                                   "".format(verfer.code))
 
         return (verfer.raw, verfer.code)
+
+
+    def _VerifyBasicEd25519(self, ked, pre):
+        """
+        Returns True if verified raises exception otherwise
+        Verify derivation of fully qualified Base64 prefix from
+        inception key event dict (ked)
+
+        Parameters:
+            ked is inception key event dict
+            pre is Base64 fully qualified prefix
+        """
+        try:
+            keys = ked["keys"]
+            if len(keys) != 1:
+                return False
+
+            if keys[0] != pre:
+                return False
+        except Exception as ex:
+            return False
+
+        return True
 
 
     def _DeriveDigBlake3_256(self, ked, seed=None, secret=None):
@@ -998,6 +1058,29 @@ class Prefixer(CryMat):
         ser = "".join(values).encode("utf-8")
         dig =  blake3.blake3(ser).digest()
         return (dig, CryOneDex.Blake3_256)
+
+
+    def _VerifyDigBlake3_256(self, ked, pre):
+        """
+        Returns True if verified raises exception otherwise
+        Verify derivation of fully qualified Base64 prefix from
+        inception key event dict (ked)
+
+        Parameters:
+            ked is inception key event dict
+            pre is Base64 fully qualified
+        """
+        try:
+            raw, code =  self._DeriveDigBlake3_256(ked=ked)
+            crymat = CryMat(raw=raw, code=CryOneDex.Blake3_256)
+            if crymat.qb64 != pre:
+                return False
+
+        except Exception as ex:
+            return False
+
+        return True
+
 
     def _DeriveSigEd25519(self, ked, seed=None, secret=None):
         """
@@ -1051,88 +1134,6 @@ class Prefixer(CryMat):
         # sig = pysodium.crypto_sign_detached(ser, signer.raw + verfer.raw)
 
         return (sigver.raw, CryTwoDex.Ed25519)
-
-
-    def verify(self, ked):
-        """
-        Returns True if derivation from iked for .code matches .qb64,
-                False otherwise
-
-        Parameters:
-            ked is inception key event dict
-        """
-        return (self._verify(ked=ked, pre=self.qb64))
-
-
-    def _VerifyBasicEd25519N(self, ked, pre):
-        """
-        Returns True if verified raises exception otherwise
-        Verify derivation of fully qualified Base64 pre from inception iked dict
-
-        Parameters:
-            ked is inception key event dict
-            pre is Base64 fully qualified prefix
-        """
-        try:
-            keys = ked["keys"]
-            if len(keys) != 1:
-                return False
-
-            if keys[0] != pre:
-                return False
-
-            if ked["nxt"]:  # must be empty
-                return False
-
-        except Exception as ex:
-            return False
-
-        return True
-
-
-    def _VerifyBasicEd25519(self, ked, pre):
-        """
-        Returns True if verified raises exception otherwise
-        Verify derivation of fully qualified Base64 prefix from
-        inception key event dict (ked)
-
-        Parameters:
-            ked is inception key event dict
-            pre is Base64 fully qualified prefix
-        """
-        try:
-            keys = ked["keys"]
-            if len(keys) != 1:
-                return False
-
-            if keys[0] != pre:
-                return False
-        except Exception as ex:
-            return False
-
-        return True
-
-
-    def _VerifyDigBlake3_256(self, ked, pre):
-        """
-        Returns True if verified raises exception otherwise
-        Verify derivation of fully qualified Base64 prefix from
-        inception key event dict (ked)
-
-        Parameters:
-            ked is inception key event dict
-            pre is Base64 fully qualified
-        """
-        try:
-            raw, code =  self._DeriveDigBlake3_256(ked=ked)
-            crymat = CryMat(raw=raw, code=CryOneDex.Blake3_256)
-            if crymat.qb64 != pre:
-                return False
-
-        except Exception as ex:
-            return False
-
-        return True
 
 
     def _VerifySigEd25519(self, ked, pre):

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -95,11 +95,57 @@ class CrySelectCodex:
     """
     two:  str = '0'  # use two character table.
     four: str = '1'  # use four character table.
+    dash: str = '-'  # use four character count table.
 
     def __iter__(self):
         return iter(astuple(self))
 
 CrySelDex = CrySelectCodex()  # Make instance
+
+
+@dataclass(frozen=True)
+class CryCntCodex:
+    """
+    CryCntCodex codex of four character length derivation codes that indicate
+    count (number) of attached receipt couplets following a receipt statement .
+    Only provide defined codes.
+    Undefined are left out so that inclusion(exclusion) via 'in' operator works.
+    .raw is empty
+
+    Note binary length of everything in CryCntCodex results in 0 Base64 pad bytes.
+
+    First two code characters select format of attached signatures
+    Next two code charaters select count total of attached signatures to an event
+    Only provide first two characters here
+    """
+    Base64: str =  '-A'  # Fully Qualified Base64 Format Receipt Couplets.
+    Base2:  str =  '-B'  # Fully Qualified Base2 Format Receipt Couplets.
+
+    def __iter__(self):
+        return iter(astuple(self))
+
+CryCntDex = CryCntCodex()  #  Make instance
+
+# Mapping of Code to Size
+# Total size  qb64
+CryCntSizes = {
+                "-A": 4,
+                "-B": 4,
+              }
+
+# size of index portion of code qb64
+CryCntIdxSizes = {
+                   "-A": 2,
+                   "-B": 2,
+                 }
+
+# total size of raw unqualified
+CryCntRawSizes = {
+                   "-A": 0,
+                   "-B": 0,
+                 }
+
+CRYCNTMAX = 4095  # maximum count value given two base 64 digits
 
 
 @dataclass(frozen=True)
@@ -204,17 +250,19 @@ CryFourRawSizes = {
                   }
 
 # all sizes in one dict
-CrySizes = dict()
+CrySizes = dict(CryCntSizes)
 CrySizes.update(CryOneSizes)
 CrySizes.update(CryTwoSizes)
 CrySizes.update(CryFourSizes)
 
 # all sizes in one dict
-CryRawSizes = dict()
+CryRawSizes = dict(CryCntRawSizes)
 CryRawSizes.update(CryOneRawSizes)
 CryRawSizes.update(CryTwoRawSizes)
 CryRawSizes.update(CryFourRawSizes)
 
+# all sizes in one dict
+CryIdxSizes = dict(CryCntIdxSizes)
 
 
 class CryMat:

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -101,6 +101,7 @@ class CrySelectCodex:
 
 CrySelDex = CrySelectCodex()  # Make instance
 
+
 @dataclass(frozen=True)
 class CryOneCodex:
     """
@@ -203,14 +204,17 @@ CryFourRawSizes = {
                   }
 
 # all sizes in one dict
-CrySizes = dict(CryOneSizes)
+CrySizes = dict()
+CrySizes.update(CryOneSizes)
 CrySizes.update(CryTwoSizes)
 CrySizes.update(CryFourSizes)
 
 # all sizes in one dict
-CryRawSizes = dict(CryOneRawSizes)
+CryRawSizes = dict()
+CryRawSizes.update(CryOneRawSizes)
 CryRawSizes.update(CryTwoRawSizes)
 CryRawSizes.update(CryFourRawSizes)
+
 
 
 class CryMat:
@@ -252,7 +256,7 @@ class CryMat:
             pad = self._pad(raw)
             if (not ( (pad == 1 and (code in CryOneDex)) or  # One or Five or Nine
                       (pad == 2 and (code in CryTwoDex)) or  # Two or Six or Ten
-                      (pad == 0 and (code in CryFourDex)) )):  #  Four or Eight
+                      (pad == 0 and (code in CryFourDex)) )):  # Four or Eight
 
                 raise ValidationError("Wrong code={} for raw={}.".format(code, raw))
 
@@ -348,6 +352,13 @@ class CryMat:
             if code not in CryTwoDex:
                 raise ValidationError("Invalid derivation code = {} in {}.".format(code, qb64))
             qb64 = qb64[:CryTwoSizes[code]]  # strip of identifier after prefix
+
+        elif code == CrySelDex.four: # first char of four char cnt code
+            pre += 3
+            code = qb64[pre-4:pre]  #  get full code
+            if code not in CryFourDex:
+                raise ValidationError("Invalid derivation code = {} in {}.".format(code, qb64))
+            qb64 = qb64[:CryFourSizes[code]]  # strip of identifier after prefix
 
         else:
             raise ValueError("Improperly coded material = {}".format(qb64))

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -57,8 +57,8 @@ TraitDex = TraitCodex()  # Make instance
 
 LogEntry = namedtuple("LogEntry", 'serder sigers')  # LogEntry for KELS KERLS DELS etc
 Location = namedtuple("Location", 'sn dig')  # Location of key event
-Logs = namedtuple("Logs", 'kevers kels kelds ooes pses')
-# kevers dict of existing Kevers indexed by pre (qb64) of each Kever
+Logs = namedtuple("Logs", 'kels kelds ooes pses')
+
 # kels Generator or Validator KELs as dict of dicts of events keyed by pre (qb64)
 # then in order by event sn str
 # mdict keys must be subclass of str
@@ -374,7 +374,7 @@ class Kever:
         """
         # update state as we go because if invalid we fail to finish init
         if logs is None:
-            logs = Logs(kevers=dict(), kels=dict(), kelds=dict(), ooes=dict(), pses=dict())
+            logs = Logs(kels=dict(), kelds=dict(), ooes=dict(), pses=dict())
 
         self.logs = logs
 
@@ -761,11 +761,14 @@ class Kevery:
     Has the following public attributes and properties:
 
     Attributes:
+        .kevers is dict of existing kevers indexed by pre (qb64) of each Kever
+        .logs is named tuple of logs
+        .framed is Boolean stream is packet framed If True Else not framed
 
     Properties:
 
     """
-    def __init__(self, framed=True, kevers=None, logs=None):
+    def __init__(self,kevers=None, logs=None,  framed=True):
         """
         Set up event stream and logs
 
@@ -773,7 +776,7 @@ class Kevery:
         self.framed = True if framed else False  # extract until end-of-stream
         self.kevers = kevers if kevers is not None else dict()
         if logs is None:
-            logs = Logs(kevers=dict(), kels=dict(), kelds=dict(), ooes=dict(), pses=dict())
+            logs = Logs(kels=dict(), kelds=dict(), ooes=dict(), pses=dict())
         self.logs = logs
 
 

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -62,14 +62,14 @@ Logs = namedtuple("Logs", 'kels kelds ooes pses')
 # kels Generator or Validator KELs as dict of dicts of events keyed by pre (qb64)
 # then in order by event sn str
 # mdict keys must be subclass of str
-# kelds Witness or Validator KERLs as dict of dicts of events keyed by pre (qb64)
-# then in order by event sn str
-# mdict keys must be subclass of str
+
 # kelds  Key Event Digest Log
 # Validator KELDs as dict of dicts of events keyed by pre  then by event dig (qb64)
+
 # ooes Out of Order Escows as dict of dicts of events keyed by pre (qb64)
 # then in order by event sn str
 # mdict keys must be subclass of str
+
 # pses Partial Signature Escows as dict of dicts of events keyed by pre (qb64)
 # then in order by event sn str
 # mdict keys must be subclass of str

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -747,10 +747,6 @@ class Kever:
         return True
 
 
-
-
-
-
 class Kevery:
     """
     Kevery is Kever (KERI key event verifier) instance factory which are

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -473,10 +473,7 @@ class Kever:
 
 
         # update logs
-        if pre in self.logs.kevers:
-            raise ValueError("Kever prefix = {} already in kevers log".format(pre))
 
-        self.logs.kevers[pre] = self
         entry = LogEntry(serder=serder, sigers=sigers)
         if pre not in self.logs.kels:
             self.logs.kels[pre] = mdict()  # supports recover forks by sn
@@ -768,12 +765,13 @@ class Kevery:
     Properties:
 
     """
-    def __init__(self, framed=True, logs=None):
+    def __init__(self, framed=True, kevers=None, logs=None):
         """
         Set up event stream and logs
 
         """
         self.framed = True if framed else False  # extract until end-of-stream
+        self.kevers = kevers if kevers is not None else dict()
         if logs is None:
             logs = Logs(kevers=dict(), kels=dict(), kelds=dict(), ooes=dict(), pses=dict())
         self.logs = logs
@@ -864,13 +862,13 @@ class Kevery:
             raise ValidationError("Invalid sn = {}".format(ked["sn"]))
         dig = serder.dig
 
-        if pre not in self.logs.kevers:  #  first seen event for pre
+        if pre not in self.kevers:  #  first seen event for pre
             if ilk == Ilks.icp:  # first seen and inception so verify event keys
                 # kever init verifies basic inception stuff and signatures
                 # raises exception if problem adds to KEL Kevers
                 # create kever from serder
                 kever = Kever(serder=serder, sigers=sigers, logs=self.logs)
-                #kever should log it
+                self.kevers[pre] = kever
 
             else:  # not inception so can't verify, add to escrow
                 # log escrowed
@@ -892,7 +890,7 @@ class Kevery:
                     DELPs[pre][dig] = LogEntry(serder=serder, sigers=sigers)
 
             else:  # rot or ixn, so sn matters
-                kever = self.logs.kevers[pre]  # get existing kever for pre
+                kever = self.kevers[pre]  # get existing kever for pre
                 sno = kever.sn + 1  # proper sn of new inorder event
 
                 if sn > sno:  # sn later than sno so out of order escrow

--- a/src/keri/db/dbing.py
+++ b/src/keri/db/dbing.py
@@ -224,9 +224,10 @@ class Logger(Databaser):
         # sub db name must include a non Base64 character to avoid namespace
         # collisions with Base64 aid prefixes. So use "."
 
+        self.kelds = self.env.open_db(key=b'kelds.')  #  open named sub db
         # dupsort=True means allow duplicates for sn indexed
         self.kels = self.env.open_db(key=b'kels.', dupsort=True)  # open named sub db
-        self.kelds = self.env.open_db(key=b'kelds.')  #  open named sub db
+
 
 
 class Dupler(Databaser):
@@ -236,9 +237,9 @@ class Dupler(Databaser):
     Attributes:
         see superclass Databaser for inherited attributes
 
-        .kels is named sub DB of key event logs indexed by identifier prefix and
+        .dels is named sub DB of duplicitous event logs indexed by identifier prefix and
                 then by sequence number of event. Allows multiple values per index.
-        .kelds is named sub DB of key event logs indexed by identifer prefix and
+        .delps is named sub DB of potentials duplicitous event logs indexed by identifer prefix and
                 then by digest of serialized key event
     Properties:
 

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -17,11 +17,12 @@ from base64 import urlsafe_b64decode as decodeB64
 
 from keri.kering import Version, Versionage
 from keri.kering import ValidationError, EmptyMaterialError, DerivationError
-from keri.core.coring import CrySelDex, CryOneDex, CryTwoDex, CryFourDex
+from keri.core.coring import CrySelDex, CryCntDex, CryOneDex, CryTwoDex, CryFourDex
+from keri.core.coring import CryCntSizes, CryCntRawSizes, CryCntIdxSizes
 from keri.core.coring import CryOneSizes, CryOneRawSizes, CryTwoSizes, CryTwoRawSizes
 from keri.core.coring import CryFourSizes, CryFourRawSizes, CrySizes, CryRawSizes
-from keri.core.coring import CryMat, Verfer, Sigver, Signer, Diger, Nexter
-from keri.core.coring import Prefixer
+from keri.core.coring import CryMat, CryCounter, Verfer, Sigver, Signer
+from keri.core.coring import Diger, Nexter, Prefixer
 from keri.core.coring import generateSigners,  generateSecrets
 from keri.core.coring import SigSelDex
 from keri.core.coring import SigCntDex, SigCntSizes, SigCntRawSizes
@@ -236,6 +237,95 @@ def test_crymat():
     assert crymat.code == CryTwoDex.Ed25519
 
     """ Done Test """
+
+def test_crycounter():
+    """
+    Test CryCounter subclass of CryMat
+    """
+    # with pytest.raises(EmptyMaterialError):
+    #    counter = SigCounter()
+
+    qsc = CryCntDex.Base64 + IntToB64(1, l=2)
+    assert qsc == '-AAB'
+
+    counter = CryCounter()
+    assert counter.raw == b''
+    assert counter.code == CryCntDex.Base64
+    assert counter.index == 1
+    assert counter.count == 1
+    assert counter.qb64 == qsc
+    assert counter.qb2 == b'\xf8\x00\x01'
+
+    counter = CryCounter(raw=b'')
+    assert counter.raw == b''
+    assert counter.code == CryCntDex.Base64
+    assert counter.index == 1
+    assert counter.count == 1
+    assert counter.qb64 == qsc
+    assert counter.qb2 == b'\xf8\x00\x01'
+
+    counter = CryCounter(qb64=qsc)
+    assert counter.raw == b''
+    assert counter.code == CryCntDex.Base64
+    assert counter.index == 1
+    assert counter.count == 1
+    assert counter.qb64 == qsc
+    assert counter.qb2 == b'\xf8\x00\x01'
+
+    counter = CryCounter(raw=b'', count=1)
+    assert counter.raw == b''
+    assert counter.code == CryCntDex.Base64
+    assert counter.index == 1
+    assert counter.qb64 == qsc
+    assert counter.qb2 == b'\xf8\x00\x01'
+
+    counter = CryCounter(raw=b'', count=0)
+    assert counter.raw == b''
+    assert counter.code == CryCntDex.Base64
+    assert counter.index == 0
+    assert counter.qb64 == '-AAA'
+    assert counter.qb2 == b'\xf8\x00\x00'
+
+
+    cnt = 5
+    qsc = SigCntDex.Base64 + IntToB64(cnt, l=2)
+    assert qsc == '-AAF'
+    counter = CryCounter(count=cnt)
+    assert counter.raw == b''
+    assert counter.code == CryCntDex.Base64
+    assert counter.index == cnt
+    assert counter.qb64 == qsc
+    assert counter.qb2 == b'\xf8\x00\x05'
+
+    counter = CryCounter(qb64=qsc)
+    assert counter.raw == b''
+    assert counter.code == CryCntDex.Base64
+    assert counter.index == cnt
+    assert counter.count == cnt
+    assert counter.qb64 == qsc
+    assert counter.qb2 == b'\xf8\x00\x05'
+
+    cnt = 5
+    qsc = CryCntDex.Base2 + IntToB64(cnt, l=2)
+    assert qsc == '-BAF'
+    counter = CryCounter(code=CryCntDex.Base2, count=cnt)
+    assert counter.raw == b''
+    assert counter.code == CryCntDex.Base2
+    assert counter.index == cnt
+    assert counter.qb64 == qsc
+    assert counter.qb2 == b'\xf8\x10\x05'
+
+    counter = CryCounter(qb64=qsc)
+    assert counter.raw == b''
+    assert counter.code == CryCntDex.Base2
+    assert counter.index == cnt
+    assert counter.count == cnt
+    assert counter.qb64 == qsc
+    assert counter.qb2 == b'\xf8\x10\x05'
+
+
+    """ Done Test """
+
 
 
 def test_verfer():
@@ -936,6 +1026,25 @@ def test_sigcounter():
     assert counter.qb64 == qsc
     assert counter.qb2 == b'\xf8\x00\x05'
 
+    cnt = 5
+    qsc = SigCntDex.Base2 + IntToB64(cnt, l=2)
+    assert qsc == '-BAF'
+    counter = SigCounter(code=SigCntDex.Base2, count=cnt)
+    assert counter.raw == b''
+    assert counter.code == SigCntDex.Base2
+    assert counter.index == cnt
+    assert counter.qb64 == qsc
+    assert counter.qb2 == b'\xf8\x10\x05'
+
+    counter = SigCounter(qb64=qsc)
+    assert counter.raw == b''
+    assert counter.code == SigCntDex.Base2
+    assert counter.index == cnt
+    assert counter.count == cnt
+    assert counter.qb64 == qsc
+    assert counter.qb2 == b'\xf8\x10\x05'
+
+
 
     """ Done Test """
 
@@ -1291,4 +1400,4 @@ def test_serder():
 
 
 if __name__ == "__main__":
-    test_prefixer()
+    test_crycounter()

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -789,8 +789,8 @@ def test_kevery():
     kevery.processAll(kes=kes)
 
     pre = kever.prefixer.qb64
-    assert pre in klogs.kevers
-    vkever = klogs.kevers[pre]
+    assert pre in kevery.kevers
+    vkever = kevery.kevers[pre]
     assert vkever.sn == kever.sn
     assert vkever.verfers[0].qb64 == kever.verfers[0].qb64
     assert vkever.verfers[0].qb64 == signers[4].verfer.qb64
@@ -947,8 +947,8 @@ def test_multisig_digaid():
     kevery.processAll(kes=kes)
 
     pre = kever.prefixer.qb64
-    assert pre in klogs.kevers
-    vkever = klogs.kevers[pre]
+    assert pre in kevery.kevers
+    vkever = kevery.kevers[pre]
     assert vkever.sn == kever.sn
     assert vkever.verfers[0].qb64 == kever.verfers[0].qb64
     assert vkever.verfers[0].qb64 == signers[5].verfer.qb64

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -783,7 +783,7 @@ def test_kevery():
 
     assert len(kes) == 3349
 
-    klogs = Logs(kevers=dict(), kels=dict(), kelds=dict(), ooes=dict(), pses=dict())
+    klogs = Logs(kels=dict(), kelds=dict(), ooes=dict(), pses=dict())
 
     kevery = Kevery(logs=klogs)
     kevery.processAll(kes=kes)
@@ -941,7 +941,7 @@ def test_multisig_digaid():
 
     assert len(kes) == 2783
 
-    klogs = Logs(kevers=dict(), kels=dict(), kelds=dict(), ooes=dict(), pses=dict())
+    klogs = Logs(kels=dict(), kelds=dict(), ooes=dict(), pses=dict())
 
     kevery = Kevery(logs=klogs)
     kevery.processAll(kes=kes)


### PR DESCRIPTION
Provides future support for streaming  receipt messages with attached receipt couplets each consisting of fully qualified witness prefix and signature. CryCounter allows inserting 4 char cry count code after serialized statement and before attached receipt couplets. This makes for compact multi-receipted messages.