### PR TITLE
Setup CI Pipeline

### DIFF
--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -1,0 +1,34 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python application
+
+on:
+  pull_request:
+    types: [opened, edited, closed, synchronize, reopened, unlocked]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest /tests

--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -23,12 +23,15 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
+    - name: Lint changes
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
+    - name: Run core KERI tests
       run: |
-        pytest tests/
+        pytest tests/ --ignore tests/demo/
+    - name: Run KERI demo tests
+      run: |
+        pytest tests/demo/

--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -31,4 +31,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest /tests
+        pytest tests/

--- a/README.md
+++ b/README.md
@@ -314,4 +314,9 @@ https://medium.com/@joehonton/cipher-suites-demystified-ada2e97be9c9
 
 ### Testing
 * Install a testing framework like pytest: `pip install pytest`
-* To run the test suite: `pytest tests/`
+* To run the test suite: 
+    ```
+    pytest tests/ --ignore tests/demo/
+    pytest tests/demo/
+    ```
+    

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Project Name:  keripy
 ### Dependencies
 #### Binaries
 
-python 3.82+
+python 3.9.1+
 libsodium 1.0.18+
 
 
@@ -306,7 +306,12 @@ https://medium.com/@joehonton/cipher-suites-demystified-ada2e97be9c9
 
 ## Development
 
-* Ensure Python 3.8 is present along with venv and dev header files;
+###Setup
+* Ensure Python 3.9 is present along with venv and dev header files;
 * Setup virtual environment: `python3 -m venv keripy`
 * Activate virtual environment: `source keripy/bin/activate`
 * Setup dependencies: `pip install -r requirements.txt`
+
+###Testing
+* Install a testing framework like pytest: `pip install pytest`
+* To run the test suite: `pytest tests/`

--- a/README.md
+++ b/README.md
@@ -306,12 +306,12 @@ https://medium.com/@joehonton/cipher-suites-demystified-ada2e97be9c9
 
 ## Development
 
-###Setup
+### Setup
 * Ensure Python 3.9 is present along with venv and dev header files;
 * Setup virtual environment: `python3 -m venv keripy`
 * Activate virtual environment: `source keripy/bin/activate`
 * Setup dependencies: `pip install -r requirements.txt`
 
-###Testing
+### Testing
 * Install a testing framework like pytest: `pip install pytest`
 * To run the test suite: `pytest tests/`

--- a/tests/db/test_doing.py
+++ b/tests/db/test_doing.py
@@ -11,8 +11,6 @@ from hio.base import doing
 from keri.db import dbing
 
 
-
-
 def test_baserdoer():
     """
     Test BaserDoer
@@ -65,9 +63,7 @@ def test_baserdoer():
         assert doer.baser.env == None
         assert not os.path.exists(doer.baser.path)
 
-
-
-    #start over
+    # start over
     doist.tyme = 0.0
     doist.do(doers=doers)
     assert doist.tyme == limit
@@ -79,6 +75,5 @@ def test_baserdoer():
     """End Test"""
 
 
-
 if __name__ == "__main__":
-    test_basedoer()
+    test_baserdoer()


### PR DESCRIPTION
This adds Github actions to automatically run the tests and a linter whenever a PR is opened or updated.  

The demo tests cause the core KERI tests to fail because the global ogler object is modified inside multiple tests.  To fix this for now I broke the tests up into two test suites. The demo tests now run on their own which fixes the test isolation issues.

The linter is flake8 and is currently set to only fail on syntax errors and undefined names.  It runs a second time and outputs all pep8 violations but will not cause any failures on this step.  

The linter did find one error in the tests with an undefined name that you'll see fixed below.