### PR TITLE
Support for escrow of unverified receipts from transferable identifier receptors (validators)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ from setuptools import setup
 
 setup(
     name='keri',
-    version='0.1.10',  #  also change in src/keri/__init__.py
+    version='0.1.11',  #  also change in src/keri/__init__.py
     license='Apache Software License 2.0',
     description='Key Event Receipt Infrastructure',
     long_description="KERI Decentralized Key Management Infrastructure",

--- a/src/keri/__init__.py
+++ b/src/keri/__init__.py
@@ -1,4 +1,4 @@
 # -*- encoding: utf-8 -*-
 
-__version__ = '0.1.10'  # also change in setup.py
+__version__ = '0.1.11'  # also change in setup.py
 

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -2442,6 +2442,8 @@ class Serder:
         .digb is qb64b digest from .diger
         .verfers is list of Verfers converted from .ked["k"]
         .sn is int sequence number converted from .ked["s"]
+        .pre is qb64 str of identifier prefix from .ked["i"]
+        .preb is qb64b bytes of identifier prefix from .ked["i"]
 
     Hidden Attributes:
           ._raw is bytes of serialized event only
@@ -2752,6 +2754,24 @@ class Serder:
         sn (sequence number) property getter
         """
         return int(self.ked["s"], 16)
+
+
+    @property
+    def pre(self):
+        """
+        Returns str qb64  of .ked["i"] (identifier prefix)
+        pre (identifier prefix) property getter
+        """
+        return self.ked["i"]
+
+
+    @property
+    def preb(self):
+        """
+        Returns bytes qb64b  of .ked["i"] (identifier prefix)
+        preb (identifier prefix) property getter
+        """
+        return self.pre.encode("utf-8")
 
 
 

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -1490,18 +1490,33 @@ class Nexter(CryMat):
 
 class Prefixer(CryMat):
     """
-    DigAider is CryMat subclass for autonomic identifier prefix using
+    Prefixer is CryMat subclass for autonomic identifier prefix using
     derivation as determined by code from ked
 
-    See CryMat for other inherited attributes and properties:
-
     Attributes:
+
+    Inherited Properties:  (see CryMat)
+        .pad  is int number of pad chars given raw
+        .code is  str derivation code to indicate cypher suite
+        .raw is bytes crypto material only without code
+        .index is int count of attached crypto material by context (receipts)
+        .qb64 is str in Base64 fully qualified with derivation code + crypto mat
+        .qb64b is bytes in Base64 fully qualified with derivation code + crypto mat
+        .qb2  is bytes in binary with derivation code + crypto material
+        .nontrans is Boolean, True when non-transferable derivation code False otherwise
 
     Properties:
 
     Methods:
         verify():  Verifies derivation of aid prefix
 
+    Hidden:
+        ._pad is method to compute  .pad property
+        ._code is str value for .code property
+        ._raw is bytes value for .raw property
+        ._index is int value for .index property
+        ._infil is method to compute fully qualified Base64 from .raw and .code
+        ._exfil is method to extract .code and .raw from fully qualified Base64
     """
     Dummy = "#"  # dummy spaceholder char for pre. Must not be a valid Base64 char
     # element labels to exclude in digest or signature derivation from inception icp
@@ -1552,12 +1567,6 @@ class Prefixer(CryMat):
             self._verify = self._verify_sig_ed25519
         else:
             raise ValueError("Unsupported code = {} for prefixer.".format(self.code))
-
-        #if ked and not self.verify(ked):
-            #raise DerivationError("Error verifying derived prefix = {} with code "
-                                  #"= {} from ked = {}.".format(self.qb64,
-                                                               #self.code,
-                                                               #ked))
 
 
     def derive(self, ked, seed=None, secret=None):

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -665,7 +665,7 @@ class SeqNumber(CryMat):
     """
     SeqNumber is subclass of CryMat, cryptographic material,
     SeqNumber provides fully qualified format for sequence numbers when
-    used a attached cryptographic material items in its .sn property.
+    used as attached cryptographic material items in its .sn property.
 
     Useful when parsing attached receipt quadlets from stream or database
 

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -541,7 +541,7 @@ class CryMat:
 
         pad = cs % 4  # pad is remainder pre mod 4
         # strip off prepended code and append pad characters
-        base = qb64b[cs:] + pad * BASE64_PAD
+        base = qb64b[cs:] + (pad * BASE64_PAD)
         raw = decodeB64(base)
 
         if len(raw) != (len(qb64b) - cs) * 3 // 4:  # exact lengths

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -541,7 +541,7 @@ class CryMat:
 
         pad = cs % 4  # pad is remainder pre mod 4
         # strip off prepended code and append pad characters
-        base = qb64b[cs:] + (pad * BASE64_PAD)
+        base = qb64b[cs:] + pad * BASE64_PAD
         raw = decodeB64(base)
 
         if len(raw) != (len(qb64b) - cs) * 3 // 4:  # exact lengths

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -31,7 +31,7 @@ from ..db.dbing import dgKey, snKey, splitKey, splitKeySn, Baser
 
 from .coring import Versify, Serials, Ilks, CryOneDex
 from .coring import Signer, Verfer, Diger, Nexter, Prefixer, Serder, Tholder
-from .coring import CryMat, CryRawSizes, CryTwoDex, SeqNumber
+from .coring import CryMat, CryRawSizes, CryTwoDex, Seqner
 from .coring import CryCounter, Cigar
 from .coring import SigCounter, Siger
 
@@ -151,7 +151,7 @@ def dequadlet(quadlet):
 
     prefixer = Prefixer(qb64b=quadlet)
     quadlet = quadlet[len(prefixer.qb64b):]  # strip off pre
-    seqnumber = SeqNumber(qb64b=quadlet)
+    seqnumber = Seqner(qb64b=quadlet)
     quadlet = quadlet[len(prefixer.qb64b):]  # strip off snu
     diger = Diger(qb64b=quadlet)
     quadlet = quadlet[len(diger.qb64b):]  # strip off dig
@@ -179,7 +179,7 @@ def dequintlet(quintlet):
     quintlet = quintlet[len(diger.qb64b):]  # strip off dig
     prefixer = Prefixer(qb64b=quintlet)  # prefixer of recipter
     quintlet = quintlet[len(prefixer.qb64b):]  # strip off pre
-    seqnumber = SeqNumber(qb64b=quintlet)  # seqnumber of receipting event
+    seqnumber = Seqner(qb64b=quintlet)  # seqnumber of receipting event
     quintlet = quintlet[len(prefixer.qb64b):]  # strip off snu
     diger = Diger(qb64b=quintlet)  # diger of receipting event
     quintlet = quintlet[len(diger.qb64b):]  # strip off dig
@@ -1652,7 +1652,7 @@ class Kevery:
         self.baser.putDts(dgKey(pre, dig), nowIso8601().encode("utf-8"))
         for cigar in cigars:  # escrow each triplet
             if cigar.verfer.transferable:  # skip transferable verfers
-                continue  # skip invalid couplets
+                continue  # skip invalid triplets
             triplet = dig.encode("utf-8") + cigar.verfer.qb64b + cigar.qb64b
             self.baser.addUre(key=snKey(pre, sn), val=triplet)  # should be snKey
         # log escrowed
@@ -1660,7 +1660,7 @@ class Kevery:
                      " sn=%x dig=%s\n", pre, sn, dig)
 
 
-    def escrowVREvent(self, edig, sigers, pre, sn, dig):
+    def escrowVREvent(self, edig, esn, sigers, pre, sn, dig):
         """
         Update associated logs for escrow of Unverified Validator Event Receipt
         (transferable)
@@ -1680,11 +1680,11 @@ class Kevery:
         # and sig stored at kel pre, sn so can compare digs
         # with different algos.  Can't lookup by dig for same reason. Must
         # lookup last event by sn not by dig.
-        self.baser.putDts(dgKey(pre, dig), nowIso8601().encode("utf-8"))
-        for siger in sigers:  # escrow each triplet
-            if siger.verfer.transferable:  # skip transferable verfers
-                continue  # skip invalid couplets
-            triplet = dig.encode("utf-8") + siger.verfer.qb64b + siger.qb64b
+        self.baser.putDts(dgKey(pre, edig), nowIso8601().encode("utf-8"))
+        for siger in sigers:  # escrow each quintlet
+            if not siger.verfer.transferable:  # skip transferable verfers
+                continue  # skip invalid quintlets
+            quintlet = edig.encode("utf-8") + siger.verfer.qb64b + siger.qb64b
             self.baser.addVre(key=snKey(pre, sn), val=triplet)  # should be snKey
         # log escrowed
         blogger.info("Kevery process: escrowed unverified validator receipt of pre= %s "
@@ -1869,7 +1869,7 @@ class Kevery:
 
         seal = SealEvent(**ked["a"])
         # convert sn in seal to fully qualified SeqNumber 24 bytes, raw 16 bytes
-        sealet = seal.i.encode("utf-8") + SeqNumber(sn=int(seal.s, 16)).qb64b + seal.d.encode("utf-8")
+        sealet = seal.i.encode("utf-8") + Seqner(sn=int(seal.s, 16)).qb64b + seal.d.encode("utf-8")
 
         # Only accept receipt if for last seen version of event at sn
         snkey = snKey(pre=pre, sn=sn)

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -176,11 +176,11 @@ def dequinlet(quinlet):
         quinlet = quinlet.encode("utf-8")  # convert to bytes
 
     ediger = Diger(qb64b=quinlet)  #  diger of receipted event
-    quinlet = quinlet[len(sdiger.qb64b):]  # strip off dig
+    quinlet = quinlet[len(ediger.qb64b):]  # strip off dig
     sprefixer = Prefixer(qb64b=quinlet)  # prefixer of recipter
     quinlet = quinlet[len(sprefixer.qb64b):]  # strip off pre
     sseqner = Seqner(qb64b=quinlet)  # seqnumber of receipting event
-    quinlet = quinlet[len(sprefixer.qb64b):]  # strip off snu
+    quinlet = quinlet[len(sseqner.qb64b):]  # strip off snu
     sdiger = Diger(qb64b=quinlet)  # diger of receipting event
     quinlet = quinlet[len(sdiger.qb64b):]  # strip off dig
     siger = Siger(qb64b=quinlet)  #  indexed siger of event

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -2458,11 +2458,11 @@ class Kevery:
                     #  compare digs
                     if not ediger.compare(ser=serder.raw, diger=ediger):
                         blogger.info("Kevery unescrow error: Bad receipt dig."
-                             "pre=%s sn=%x receipter=%s\n", (pre, sn, eprefixer.qb64))
+                             "pre=%s sn=%x receipter=%s\n", (pre, sn, sprefixer.qb64))
 
                         raise ValidationError("Bad escrowed receipt dig at "
                                           "pre={} sn={:x} receipter={}."
-                                          "".format( pre, sn, eprefixer.qb64))
+                                          "".format( pre, sn, sprefixer.qb64))
 
                     # get receipter's last est event
                     # retrieve dig of last event at sn of receipter.

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -1691,10 +1691,10 @@ class Kevery:
         # fetch ked ilk  pre, sn, dig to see how to process
         ked = serder.ked
         try:  # see if pre in event validates
-            prefixer = Prefixer(qb64=ked["i"])
+            prefixer = Prefixer(qb64b=serder.preb)
         except Exception as ex:
             raise ValidationError("Invalid pre = {} for evt = {}."
-                                  "".format(ked["i"], ked))
+                                  "".format(serder.pre, ked))
         pre = prefixer.qb64
         ked = serder.ked
         sn = self.validateSN(ked)

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -826,7 +826,7 @@ class Kever:
                                        [verfer.qb64 for verfer in self.verfers],
                                        ked))
 
-        self.prefixer = Prefixer(qb64=ked["i"])
+        self.prefixer = Prefixer(qb64=serder.pre)
         if not self.prefixer.verify(ked=ked):  # invalid prefix
             raise ValidationError("Invalid prefix = {} for inception evt = {}."
                                   "".format(self.prefixer.qb64, ked))

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -1669,7 +1669,7 @@ class Kevery:
         # lookup last event by sn not by dig.
         self.baser.putDts(dgKey(serder.preb, dig), nowIso8601().encode("utf-8"))
         prelet = (dig.encode("utf-8") + seal.i.encode("utf-8") +
-                  Seqner(sn=seal.s).qb64b + seal.d.encode("utf-8"))
+                  Seqner(snh=seal.s).qb64b + seal.d.encode("utf-8"))
         for siger in sigers:  # escrow each quintlet
             quinlet = prelet +  siger.qb64b  # quinlet
             self.baser.addVre(key=snKey(serder.preb, serder.sn), val=quinlet)
@@ -2410,7 +2410,7 @@ class Kevery:
             for ekey, equinlet in self.baser.getVreItemsNextIter(key=key):
                 try:
                     pre, sn = splitKeySn(ekey)  # get pre and sn from escrow item
-                    ediger, sprefixer, ssegner, sdiger, siger = dequinlet(equinlet)
+                    ediger, sprefixer, sseqner, sdiger, siger = dequinlet(equinlet)
 
                     # check date if expired then remove escrow.
                     dtb = self.baser.getDts(dgKey(pre, bytes(ediger.qb64b)))
@@ -2467,7 +2467,7 @@ class Kevery:
                     # get receipter's last est event
                     # retrieve dig of last event at sn of receipter.
                     sdig = self.baser.getKeLast(key=snKey(pre=sprefixer.qb64b,
-                                                          sn=ssegner.sn))
+                                                          sn=sseqner.sn))
                     if sdig is None:
                         # no event so keep in escrow
                         blogger.info("Kevery unescrow error: Missing receipted "

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -152,12 +152,12 @@ def dequadlet(quadlet):
 
     prefixer = Prefixer(qb64b=quadlet)
     quadlet = quadlet[len(prefixer.qb64b):]  # strip off pre
-    seqnumber = Seqner(qb64b=quadlet)
-    quadlet = quadlet[len(prefixer.qb64b):]  # strip off snu
+    seqner = Seqner(qb64b=quadlet)
+    quadlet = quadlet[len(seqner.qb64b):]  # strip off snu
     diger = Diger(qb64b=quadlet)
     quadlet = quadlet[len(diger.qb64b):]  # strip off dig
     siger = Siger(qb64b=quadlet)
-    return (prefixer, seqnumber, diger, siger)
+    return (prefixer, seqner, diger, siger)
 
 
 def dequinlet(quinlet):

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -778,8 +778,10 @@ class Kever:
         self.config(serder=serder, estOnly=estOnly)  # assign config traits perms
 
         # validates if not escrows as needed and raises validation error
-        self.validateSigs(serder=serder, sigers=sigers, verfers=serder.verfers,
-                          tholder=self.tholder, sn=self.sn)
+        self.validateSigs(serder=serder,
+                          sigers=sigers,
+                          verfers=serder.verfers,
+                          tholder=self.tholder)
 
         if ilk == Ilks.dip:
             seal = self.validateSeal(serder=serder, sigers=sigers)
@@ -884,7 +886,7 @@ class Kever:
             raise ValidationError("Unexpected event = {} in nontransferable "
                                   " state.".format(serder.ked))
         ked = serder.ked
-        if ked["i"] != self.prefixer.qb64:
+        if serder.pre != self.prefixer.qb64:
             raise ValidationError("Mismatch event aid prefix = {} expecting"
                                   " = {} for evt = {}.".format(ked["i"],
                                                                self.prefixer.qb64,
@@ -908,8 +910,10 @@ class Kever:
             tholder, toad, wits = self.rotate(serder, sn)
 
             # validates and escrows as needed raises ValidationError if not successful
-            self.validateSigs(serder=serder, sigers=sigers, verfers=serder.verfers,
-                              tholder=tholder, sn=sn)
+            self.validateSigs(serder=serder,
+                              sigers=sigers,
+                              verfers=serder.verfers,
+                              tholder=tholder)
 
             if ilk == Ilks.drt:
                 seal = self.validateSeal(serder=serder, sigers=sigers)
@@ -960,8 +964,10 @@ class Kever:
 
             # interaction event use sith and keys from pre-existing Kever state
             # validates and escrows as needed
-            self.validateSigs(serder=serder, sigers=sigers, verfers=self.verfers,
-                              tholder=self.tholder, sn=sn)
+            self.validateSigs(serder=serder,
+                              sigers=sigers,
+                              verfers=self.verfers,
+                              tholder=self.tholder)
 
             # update state
             self.sn = sn
@@ -1166,7 +1172,7 @@ class Kever:
 
 
 
-    def validateSigs(self, serder, sigers, verfers, tholder, sn):
+    def validateSigs(self, serder, sigers, verfers, tholder):
         """
         Validate signatures by validating sith indexs and verifying signatures
 
@@ -1187,27 +1193,13 @@ class Kever:
 
         indices = self.verifySigs(serder, sigers, verfers)
 
-        ## verify indexes of attached signatures against verifiers
-        #for siger in sigers:
-            #if siger.index >= len(verfers):
-                #raise ValidationError("Index = {} to large for keys for evt = "
-                                      #"{}.".format(siger.index, serder.ked))
-            #siger.verfer = verfers[siger.index]  # assign verfer
-
-        ## verify signatures
-        #indices = []
-        #for siger in sigers:
-            #if siger.verfer.verify(siger.raw, serder.raw):
-                #indices.append(siger.index)
-
         if not indices:  # must have a least one verified
             raise ValidationError("No verified signatures among {} for evt = {}."
                                   "".format([siger.qb64 for siger in sigers],
                                             serder.ked))
 
         if not tholder.satisfy(indices):  #  at least one but not enough
-            self.escrowPSEvent(serder=serder, sigers=sigers,
-                                   pre=self.prefixer.qb64b, sn=sn)
+            self.escrowPSEvent(serder=serder, sigers=sigers)
 
             raise MissingSignatureError("Failure satisfying sith = {} on sigs for {}"
                                   " for evt = {}.".format(tholder.sith,
@@ -1241,8 +1233,7 @@ class Kever:
             #  escrow event here
             inceptive = True if serder.ked["t"] in (Ilks.icp, Ilks.dip) else False
             sn = self.validateSN(ked=serder.ked, inceptive=inceptive)
-            self.escrowPSEvent(serder=serder, sigers=sigers,
-                             pre=self.prefixer.qb64b, sn=sn)
+            self.escrowPSEvent(serder=serder, sigers=sigers)
             raise MissingDelegatingSealError("No delegating event at seal = {} for "
                                              "evt = {}.".format(serder.ked["da"],
                                                      serder.ked))
@@ -1315,7 +1306,7 @@ class Kever:
         blogger.info("Kever process: added valid event to KEL event = %s\n", serder.ked)
 
 
-    def escrowPSEvent(self, serder, sigers, pre, sn):
+    def escrowPSEvent(self, serder, sigers):
         """
         Update associated logs for escrow of partially signed event
         or fully signed delegated event but without delegating event
@@ -1323,8 +1314,6 @@ class Kever:
         Parameters:
             serder is Serder instance of  event
             sigers is list of Siger instance for  event
-            pre is str qb64 of identifier prefix of event
-            sn is int sequence number of event
         """
         dgkey = dgKey(serder.preb, serder.digb)
         self.baser.putDts(dgkey, nowIso8601().encode("utf-8"))

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -1669,7 +1669,7 @@ class Kevery:
         # lookup last event by sn not by dig.
         self.baser.putDts(dgKey(serder.preb, dig), nowIso8601().encode("utf-8"))
         prelet = (dig.encode("utf-8") + seal.i.encode("utf-8") +
-                  Seqner(sn=int(seal.s, 16)).qb64b + seal.d.encode("utf-8"))
+                  Seqner(sn=seal.s).qb64b + seal.d.encode("utf-8"))
         for siger in sigers:  # escrow each quintlet
             quinlet = prelet +  siger.qb64b  # quinlet
             self.baser.addVre(key=snKey(serder.preb, serder.sn), val=quinlet)
@@ -2407,7 +2407,7 @@ class Kevery:
         ims = bytearray()
         key = ekey = b''  # both start same. when not same means escrows found
         while True:  # break when done
-            for ekey, equinlet in self.baser.getUreItemsNextIter(key=key):
+            for ekey, equinlet in self.baser.getVreItemsNextIter(key=key):
                 try:
                     pre, sn = splitKeySn(ekey)  # get pre and sn from escrow item
                     ediger, sprefixer, ssegner, sdiger, siger = dequinlet(equinlet)

--- a/src/keri/db/dbing.py
+++ b/src/keri/db/dbing.py
@@ -1345,6 +1345,7 @@ class Baser(LMDBer):
         """
         Use dgKey()
         Write each entry from list of bytes receipt quadlets vals to key
+        quadlet is spre+ssnu+sdig+sig
         Adds to existing receipts at key if any
         Returns True If no error
         Apparently always returns True (is this how .put works with dupsort=True)
@@ -1357,6 +1358,7 @@ class Baser(LMDBer):
         """
         Use dgKey()
         Add receipt quadlet val bytes as dup to key in db
+        quadlet is spre+ssnu+sdig+sig
         Adds to existing values at key if any
         Returns True if written else False if dup val already exists
         Duplicates are inserted in lexocographic order not insertion order.
@@ -1368,6 +1370,7 @@ class Baser(LMDBer):
         """
         Use dgKey()
         Return list of receipt quadlet at key
+        quadlet is spre+ssnu+sdig+sig
         Returns empty list if no entry at key
         Duplicates are retrieved in lexocographic order not insertion order.
         """
@@ -1378,6 +1381,7 @@ class Baser(LMDBer):
         """
         Use dgKey()
         Return iterator of receipt quadlets at key
+        quadlet is spre+ssnu+sdig+sig
         Raises StopIteration Error when empty
         Duplicates are retrieved in lexocographic order not insertion order.
         """

--- a/src/keri/db/dbing.py
+++ b/src/keri/db/dbing.py
@@ -1229,7 +1229,6 @@ class Baser(LMDBer):
         Write each entry from list of bytes receipt triples vals to key
         Triplet is dig + pre + sig
         Adds to existing receipts at key if any
-        Returns True If no error
         Returns True If at least one of vals is added as dup, False otherwise
         Duplicates are inserted in insertion order.
         """
@@ -1405,63 +1404,120 @@ class Baser(LMDBer):
 
     def putVres(self, key, vals):
         """
-        Use dgKey()
-        Write each entry from list of bytes receipt quadlets vals to key
+        Use snKey()
+        Write each entry from list of bytes receipt quinlets vals to key
+        Quinlet is edig + spre + ssnu + sdig +sig
         Adds to existing receipts at key if any
-        Returns True If no error
-        Apparently always returns True (is this how .put works with dupsort=True)
-        Duplicates are inserted in lexocographic order not insertion order.
+        Returns True If at least one of vals is added as dup, False otherwise
+        Duplicates are inserted in insertion order.
         """
-        return self.putVals(self.vres, key, vals)
+        return self.putIoVals(self.vres, key, vals)
 
 
     def addVre(self, key, val):
         """
-        Use dgKey()
-        Add receipt quadlet val bytes as dup to key in db
+        Use snKey()
+        Add receipt quinlet val bytes as dup to key in db
+        Quinlet is edig + spre + ssnu + sdig +sig
         Adds to existing values at key if any
-        Returns True if written else False if dup val already exists
-        Duplicates are inserted in lexocographic order not insertion order.
+        Returns True If at least one of vals is added as dup, False otherwise
+        Duplicates are inserted in insertion order.
         """
-        return self.addVal(self.vres, key, val)
+        return self.addIoVal(self.vres, key, val)
 
 
     def getVres(self, key):
         """
-        Use dgKey()
-        Return list of receipt quadlet at key
+        Use snKey()
+        Return list of receipt quinlets at key
+        Quinlet is edig + spre + ssnu + sdig +sig
         Returns empty list if no entry at key
-        Duplicates are retrieved in lexocographic order not insertion order.
+        Duplicates are retrieved in insertion order.
         """
-        return self.getVals(self.vres, key)
+        return self.getIoVals(self.vres, key)
 
 
     def getVresIter(self, key):
         """
-        Use dgKey()
-        Return iterator of receipt quadlets at key
+        Use snKey()
+        Return iterator of receipt quinlets at key
+        Quinlet is edig + spre + ssnu + sdig +sig
         Raises StopIteration Error when empty
-        Duplicates are retrieved in lexocographic order not insertion order.
+        Duplicates are retrieved in insertion order.
         """
-        return self.getValsIter(self.vres, key)
+        return self.getIoValsIter(self.vres, key)
+
+
+    def getVreLast(self, key):
+        """
+        Use snKey()
+        Return last inserted dup partial signed escrowed event quinlet val at key
+        Quinlet is edig + spre + ssnu + sdig +sig
+        Returns None if no entry at key
+        Duplicates are retrieved in insertion order.
+        """
+        return self.getIoValLast(self.vres, key)
+
+
+    def getVreItemsNext(self, key=b'', skip=True):
+        """
+        Use snKey()
+        Return all dups of partial signed escrowed event quinlet items at next
+        key after key.
+        Item is (key, val) where proem has already been stripped from val
+        val is Quinlet is edig + spre + ssnu + sdig +sig
+        If key is b'' empty then returns dup items at first key.
+        If skip is False and key is not b'' empty then returns dup items at key
+        Returns empty list if no entry at key
+        Duplicates are retrieved in insertion order.
+        """
+        return self.getIoItemsNext(self.vres, key, skip)
+
+
+    def getVreItemsNextIter(self, key=b'', skip=True):
+        """
+        Use sgKey()
+        Return iterator of partial signed escrowed event quinlet items at next
+        key after key.
+        Items is (key, val) where proem has already been stripped from val
+        val is Quinlet is edig + spre + ssnu + sdig +sig
+        If key is b'' empty then returns dup items at first key.
+        If skip is False and key is not b'' empty then returns dup items at key
+        Raises StopIteration Error when empty
+        Duplicates are retrieved in insertion order.
+        """
+        return self.getIoItemsNextIter(self.vres, key, skip)
 
 
     def cntVres(self, key):
         """
-        Use dgKey()
-        Return count of receipt quadlets at key
+        Use snKey()
+        Return count of receipt quinlets at key
         Returns zero if no entry at key
         """
-        return self.cntVals(self.vres, key)
+        return self.cntIoVals(self.vres, key)
 
 
-    def delVres(self, key, val=b''):
+    def delVres(self, key):
         """
-        Use dgKey()
-        Deletes all values at key if val = b'' else deletes dup val = val.
-        Returns True If key exists in database (or key, val if val not b'') Else False
+         Use snKey()
+        Deletes all values at key in db.
+        Returns True If key exists in database Else False
         """
-        return self.delVals(self.vres, key, val)
+        return self.delIoVals(self.vres, key)
+
+
+    def delVre(self, key, val):
+        """
+        Use snKey()
+        Deletes dup val at key in db.
+        Returns True If dup at  exists in db Else False
+
+        Parameters:
+            key is bytes of key within sub db's keyspace
+            val is dup val (does not include insertion ordering proem)
+        """
+        return self.delIoVal(self.vres, key, val)
 
 
     def putKes(self, key, vals):

--- a/src/keri/kering.py
+++ b/src/keri/kering.py
@@ -68,11 +68,20 @@ class LikelyDuplicitousError(ValidationError):
         raise LikelyDuplicitousError("error message")
     """
 
+
 class UnverifiedReceiptError(ValidationError):
     """
     Error reciept is unverfied
     Usage:
         raise UnverifiedReceiptError("error message")
+    """
+
+
+class UnverifiedTransferableReceiptError(ValidationError):
+    """
+    Error reciept from transferable identifier (validator) is unverfied
+    Usage:
+        raise UnverifiedTransferableReceiptError("error message")
     """
 
 

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -880,6 +880,23 @@ def test_diger():
     assert diger.code == CryOneDex.Blake3_256
     assert len(diger.raw) == CryOneRawSizes[diger.code]
     assert diger.verify(ser=ser)
+    assert diger.qb64b == b'EsLkveIFUPvt38xhtgYYJRCCpAGO7WjjHVR37Pawv67E'
+
+    digb = b'EsLkveIFUPvt38xhtgYYJRCCpAGO7WjjHVR37Pawv67E'
+    dig =  'EsLkveIFUPvt38xhtgYYJRCCpAGO7WjjHVR37Pawv67E'
+    diger = Diger(qb64b=digb)
+    assert diger.qb64b == digb
+    assert diger.qb64 == dig
+    assert diger.code == CryOneDex.Blake3_256
+
+    diger = Diger(qb64=dig)
+    assert diger.qb64 == dig
+    assert diger.qb64b == digb
+    assert diger.code == CryOneDex.Blake3_256
+
+    pig = b'sLkveIFUPvt38xhtgYYJRCCpAGO7WjjHVR37Pawv67E='
+    raw = decodeB64(pig)
+    assert pig == encodeB64(raw)
 
     dig = hashlib.blake2b(ser, digest_size=32).digest()
     diger = Diger(raw=dig, code=CryOneDex.Blake2b_256)
@@ -2217,4 +2234,4 @@ def test_tholder():
 
 
 if __name__ == "__main__":
-    test_prefixer()
+    test_diger()

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -1795,6 +1795,8 @@ def test_serder():
     assert serder.verfers == []
     assert serder.raw == b'{"v":"KERI10JSON00003c_","i":"ABCDEFG","s":"0001","t":"rot"}'
     assert serder.sn == 1
+    assert serder.pre == "ABCDEFG"
+    assert serder.preb == b"ABCDEFG"
 
     e1s = json.dumps(e1, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
     assert e1s == b'{"v":"KERI10JSON00003c_","i":"ABCDEFG","s":"0001","t":"rot"}'
@@ -1907,6 +1909,8 @@ def test_serder():
     assert evt1.raw == e1ss[:size1]
     assert evt1.version == vers1
     assert evt1.sn == 1
+    assert serder.pre == "ABCDEFG"
+    assert serder.preb == b"ABCDEFG"
 
     # test digest properties .diger and .dig
     assert evt1.diger.qb64 == evt1.dig
@@ -1926,6 +1930,8 @@ def test_serder():
     assert evt1.version == vers1
     assert evt1.diger.code == CryOneDex.Blake3_256
     assert serder.sn == 1
+    assert serder.pre == "ABCDEFG"
+    assert serder.preb == b"ABCDEFG"
 
     evt2 = Serder(raw=e2ss)
     assert evt2.kind == kind2

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -35,7 +35,7 @@ from keri.core.coring import (SigSelDex, SigCntDex, SigCntSizes, SigCntRawSizes,
                               SigFiveDex, SigFiveSizes, SigFiveRawSizes,
                               SigSizes, SigRawSizes, MINSIGSIZE)
 from keri.core.coring import IntToB64, B64ToInt
-from keri.core.coring import SigMat, SigCounter, SeqNumber, Siger
+from keri.core.coring import SigMat, SigCounter, Seqner, Siger
 from keri.core.coring import Serialage, Serials, Mimes, Vstrings
 from keri.core.coring import Versify, Deversify, Rever, VERFULLSIZE, MINSNIFFSIZE
 from keri.core.coring import Serder, Tholder
@@ -464,14 +464,15 @@ def test_crycounter():
     """ Done Test """
 
 
-def test_seqnumber():
+def test_seqner():
     """
-    Test SeqNumber subclass of CryMat
+    Test Seqner sequence number subclass of CryMat
     """
-    number = SeqNumber()  #  defaults to zero
+    number = Seqner()  #  defaults to zero
     assert number.raw == b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
     assert number.code == CryTwoDex.Salt_128
     assert number.sn == 0
+    assert number.snh == '0'
     assert number.qb64 == '0AAAAAAAAAAAAAAAAAAAAAAA'
     assert number.qb64b == b'0AAAAAAAAAAAAAAAAAAAAAAA'
     assert number.qb2 == b'\xd0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
@@ -482,115 +483,137 @@ def test_seqnumber():
     snqb2 = b'\xd0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
     with pytest.raises(ValidationError):
-        number = SeqNumber(raw=b'')
+        number = Seqner(raw=b'')
 
-    number = SeqNumber(qb64b=snqb64b)
+    number = Seqner(qb64b=snqb64b)
     assert number.raw == snraw
     assert number.code == CryTwoDex.Salt_128
     assert number.sn == 0
+    assert number.snh == '0'
     assert number.qb64 == snqb64
     assert number.qb64b == snqb64b
     assert number.qb2 == snqb2
 
-    number = SeqNumber(qb64=snqb64)
+    number = Seqner(qb64=snqb64)
     assert number.raw == snraw
     assert number.code == CryTwoDex.Salt_128
     assert number.sn == 0
+    assert number.snh == '0'
     assert number.qb64 == snqb64
     assert number.qb64b == snqb64b
     assert number.qb2 == snqb2
 
-    number = SeqNumber(qb2=snqb2)
+    number = Seqner(qb2=snqb2)
     assert number.raw == snraw
     assert number.code == CryTwoDex.Salt_128
     assert number.sn == 0
+    assert number.snh == '0'
     assert number.qb64 == snqb64
     assert number.qb64b == snqb64b
     assert number.qb2 == snqb2
 
-    number = SeqNumber(raw=snraw)
+    number = Seqner(raw=snraw)
     assert number.raw == snraw
     assert number.code == CryTwoDex.Salt_128
     assert number.sn == 0
+    assert number.snh == '0'
     assert number.qb64 == snqb64
     assert number.qb64b == snqb64b
     assert number.qb2 == snqb2
 
-    # test priority lower for sn
-    number = SeqNumber(qb64b=snqb64b, sn=5)
+    # test priority lower for sn and snh
+    number = Seqner(qb64b=snqb64b, sn=5, snh='a')
     assert number.raw == snraw
     assert number.code == CryTwoDex.Salt_128
     assert number.sn == 0
+    assert number.snh == '0'
     assert number.qb64 == snqb64
     assert number.qb64b == snqb64b
     assert number.qb2 == snqb2
 
-    number = SeqNumber(qb64=snqb64, sn=5)
+    number = Seqner(qb64=snqb64, sn=5, snh='a')
     assert number.raw == snraw
     assert number.code == CryTwoDex.Salt_128
     assert number.sn == 0
+    assert number.snh == '0'
     assert number.qb64 == snqb64
     assert number.qb64b == snqb64b
     assert number.qb2 == snqb2
 
-    number = SeqNumber(qb2=snqb2, sn=5)
+    number = Seqner(qb2=snqb2, sn=5, snh='a')
     assert number.raw == snraw
     assert number.code == CryTwoDex.Salt_128
     assert number.sn == 0
+    assert number.snh == '0'
     assert number.qb64 == snqb64
     assert number.qb64b == snqb64b
     assert number.qb2 == snqb2
 
-    number = SeqNumber(raw=snraw, sn=5)
+    number = Seqner(raw=snraw, sn=5, snh='a')
     assert number.raw == snraw
     assert number.code == CryTwoDex.Salt_128
     assert number.sn == 0
+    assert number.snh == '0'
     assert number.qb64 == snqb64
     assert number.qb64b == snqb64b
     assert number.qb2 == snqb2
 
-    #test other sn
-    number = SeqNumber(sn=5)
+    number = Seqner(sn=5, snh='a')
     assert number.raw == b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05'
     assert number.code == CryTwoDex.Salt_128
     assert number.sn == 5
+    assert number.snh == '5'
     assert number.qb64 == '0AAAAAAAAAAAAAAAAAAAAABQ'
     assert number.qb64b == b'0AAAAAAAAAAAAAAAAAAAAABQ'
     assert number.qb2 == b'\xd0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00P'
 
+    number = Seqner(snh='a')
+    assert number.raw == b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\n'
+    assert number.code == CryTwoDex.Salt_128
+    assert number.sn == 10
+    assert number.snh == 'a'
+    assert number.qb64 == '0AAAAAAAAAAAAAAAAAAAAACg'
+    assert number.qb64b == b'0AAAAAAAAAAAAAAAAAAAAACg'
+    assert number.qb2 == b'\xd0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xa0'
+
+    # More tests
     snraw = b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05'
     snqb64b = b'0AAAAAAAAAAAAAAAAAAAAABQ'
     snqb64 = '0AAAAAAAAAAAAAAAAAAAAABQ'
     snqb2 = b'\xd0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00P'
 
-    number = SeqNumber(qb64b=snqb64b)
+    number = Seqner(qb64b=snqb64b)
     assert number.raw == snraw
     assert number.code == CryTwoDex.Salt_128
     assert number.sn == 5
+    assert number.snh == '5'
     assert number.qb64 == snqb64
     assert number.qb64b == snqb64b
     assert number.qb2 == snqb2
 
-    number = SeqNumber(qb64=snqb64)
+    number = Seqner(qb64=snqb64)
     assert number.raw == snraw
     assert number.code == CryTwoDex.Salt_128
     assert number.sn == 5
+    assert number.snh == '5'
     assert number.qb64 == snqb64
     assert number.qb64b == snqb64b
     assert number.qb2 == snqb2
 
-    number = SeqNumber(qb2=snqb2, sn=5)
+    number = Seqner(qb2=snqb2, sn=5)
     assert number.raw == snraw
     assert number.code == CryTwoDex.Salt_128
     assert number.sn == 5
+    assert number.snh == '5'
     assert number.qb64 == snqb64
     assert number.qb64b == snqb64b
     assert number.qb2 == snqb2
 
-    number = SeqNumber(raw=snraw, sn=5)
+    number = Seqner(raw=snraw, sn=5)
     assert number.raw == snraw
     assert number.code == CryTwoDex.Salt_128
     assert number.sn == 5
+    assert number.snh == '5'
     assert number.qb64 == snqb64
     assert number.qb64b == snqb64b
     assert number.qb2 == snqb2
@@ -1771,6 +1794,7 @@ def test_serder():
     assert serder.size == 60
     assert serder.verfers == []
     assert serder.raw == b'{"v":"KERI10JSON00003c_","i":"ABCDEFG","s":"0001","t":"rot"}'
+    assert serder.sn == 1
 
     e1s = json.dumps(e1, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
     assert e1s == b'{"v":"KERI10JSON00003c_","i":"ABCDEFG","s":"0001","t":"rot"}'
@@ -1882,6 +1906,7 @@ def test_serder():
     assert evt1.size == size1
     assert evt1.raw == e1ss[:size1]
     assert evt1.version == vers1
+    assert evt1.sn == 1
 
     # test digest properties .diger and .dig
     assert evt1.diger.qb64 == evt1.dig
@@ -1900,6 +1925,7 @@ def test_serder():
     assert evt1.raw == e1ss[:size1]
     assert evt1.version == vers1
     assert evt1.diger.code == CryOneDex.Blake3_256
+    assert serder.sn == 1
 
     evt2 = Serder(raw=e2ss)
     assert evt2.kind == kind2
@@ -1945,6 +1971,8 @@ def test_serder():
     assert evt1.size == size2
     assert evt1.raw == e2ss[:size2]
     assert evt1.version == vers1
+    assert evt1.dig == 'EbUOh76KAyZRbHsi9_uixhnX3zkcmN2bkIh-enCOmPRU'
+    assert evt1.diger.verify(evt1.raw)
 
     #  round trip
     evt2 = Serder(raw=evt1.raw)
@@ -2126,4 +2154,4 @@ def test_tholder():
 
 
 if __name__ == "__main__":
-    test_prefixer()
+    test_serder()

--- a/tests/core/test_escrow.py
+++ b/tests/core/test_escrow.py
@@ -1020,7 +1020,7 @@ def test_unverified_trans_receipt_escrow():
 
         # create chit receipt(s) of inception message
         seal = eventing.SealEvent(i=rpre,
-                                  s=rsrdr.sn,
+                                  s=rsrdr.ked["s"],
                                   d=rsrdr.dig)
         reserder = eventing.chit(pre=pre, sn=0, dig=icpdig, seal=seal)
         # sign event not receipt
@@ -1091,8 +1091,8 @@ def test_unverified_trans_receipt_escrow():
         # create receipt(s) of interaction message with receipter rotation message
         # create chit receipt(s) of interaction message
         seal = eventing.SealEvent(i=rpre,
-                                      s=rsrdr.sn,
-                                      d=rsrdr.dig)
+                                  s=rsrdr.ked["s"],
+                                  d=rsrdr.dig)
         reserder = eventing.chit(pre=pre, sn=1, dig=ixndig, seal=seal)
         # sign event not receipt
         resigers = mgr.sign(ser=srdr.raw, verfers=rverfers)
@@ -1154,7 +1154,7 @@ def test_unverified_trans_receipt_escrow():
         # create receipt(s) of rotation message with rotation message of receipter
         # create chit receipt(s) of interaction message
         seal = eventing.SealEvent(i=rpre,
-                                      s=rsrdr.sn,
+                                      s= rsrdr.ked["s"],
                                       d=rsrdr.dig)
         reserder = eventing.chit(pre=pre, sn=2, dig=rotdig, seal=seal)
         # sign event not receipt
@@ -1264,24 +1264,23 @@ def test_unverified_trans_receipt_escrow():
         assert len(kvy.baser.getVres(dbing.snKey(pre, 2))) == 0
 
         # verify receipts
-        receipts = kvy.baser.getRcts(dbing.dgKey(pre, icpdig))
-        assert len(receipts) == 2
-        rctPrefixer, rctCigar = eventing.decouplet(receipts[0])
-        assert rctPrefixer.qb64 == wit0pre
-        rctPrefixer, rctCigar = eventing.decouplet(receipts[1])
-        assert rctPrefixer.qb64 == wit1pre
-        receipts = kvy.baser.getRcts(dbing.dgKey(pre, ixndig))
-        assert len(receipts) == 2
-        rctPrefixer, rctCigar = eventing.decouplet(receipts[0])
-        assert rctPrefixer.qb64 == wit0pre
-        rctPrefixer, rctCigar = eventing.decouplet(receipts[1])
-        assert rctPrefixer.qb64 == wit1pre
-        receipts = kvy.baser.getRcts(dbing.dgKey(pre, rotdig))
-        assert len(receipts) == 2
-        rctPrefixer, rctCigar = eventing.decouplet(receipts[0])
-        assert rctPrefixer.qb64 == wit0pre
-        rctPrefixer, rctCigar = eventing.decouplet(receipts[1])
-        assert rctPrefixer.qb64 == wit1pre
+        receipts = kvy.baser.getVrcs(dbing.dgKey(pre, icpdig))
+        assert len(receipts) == 3
+        #rctPrefixer, rctCigar = eventing.decouplet(receipts[0])
+        #assert rctPrefixer.qb64 == wit0pre
+
+
+        receipts = kvy.baser.getVrcs(dbing.dgKey(pre, ixndig))
+        assert len(receipts) == 3
+        #rctPrefixer, rctCigar = eventing.decouplet(receipts[0])
+        #assert rctPrefixer.qb64 == wit0pre
+
+
+        receipts = kvy.baser.getVrcs(dbing.dgKey(pre, rotdig))
+        assert len(receipts) == 3
+        #rctPrefixer, rctCigar = eventing.decouplet(receipts[0])
+        #assert rctPrefixer.qb64 == wit0pre
+
 
 
     assert not os.path.exists(kpr.path)

--- a/tests/core/test_escrow.py
+++ b/tests/core/test_escrow.py
@@ -1266,22 +1266,24 @@ def test_unverified_trans_receipt_escrow():
         # verify receipts
         receipts = kvy.baser.getVrcs(dbing.dgKey(pre, icpdig))
         assert len(receipts) == 3
-        #rctPrefixer, rctCigar = eventing.decouplet(receipts[0])
-        #assert rctPrefixer.qb64 == wit0pre
-
+        rctPrefixer, rctSeqner, rctDiger, rctSiger = eventing.dequadlet(receipts[0])
+        assert rctPrefixer.qb64 == rpre
+        assert rctSeqner.sn == 0
+        assert rctDiger.qb64 == ricpdig
 
         receipts = kvy.baser.getVrcs(dbing.dgKey(pre, ixndig))
         assert len(receipts) == 3
-        #rctPrefixer, rctCigar = eventing.decouplet(receipts[0])
-        #assert rctPrefixer.qb64 == wit0pre
-
+        rctPrefixer, rctSeqner, rctDiger, rctSiger = eventing.dequadlet(receipts[0])
+        assert rctPrefixer.qb64 == rpre
+        assert rctSeqner.sn == 1
+        assert rctDiger.qb64 == rrotdig
 
         receipts = kvy.baser.getVrcs(dbing.dgKey(pre, rotdig))
         assert len(receipts) == 3
-        #rctPrefixer, rctCigar = eventing.decouplet(receipts[0])
-        #assert rctPrefixer.qb64 == wit0pre
-
-
+        rctPrefixer, rctSeqner, rctDiger, rctSiger = eventing.dequadlet(receipts[0])
+        assert rctPrefixer.qb64 == rpre
+        assert rctSeqner.sn == 1
+        assert rctDiger.qb64 == rrotdig
 
     assert not os.path.exists(kpr.path)
     assert not os.path.exists(db.path)

--- a/tests/core/test_escrow.py
+++ b/tests/core/test_escrow.py
@@ -948,6 +948,348 @@ def test_unverified_receipt_escrow():
     """End Test"""
 
 
+def test_unverified_trans_receipt_escrow():
+    """
+    Test unverified transferable receipt escrow
+
+    """
+    salt = coring.Salter(raw=b'0123456789abcdef').qb64  # init Salter
+
+    # init event DB and keep DB
+    with dbing.openDB(name="edy") as db, keeping.openKeep(name="edy") as kpr:
+        # Init key pair manager
+        mgr = keeping.Manager(keeper=kpr, salt=salt)
+
+        # Init Kevery with event DB
+        kvy = eventing.Kevery(baser=db)
+
+
+        # create inception event with 3 keys each in incept and next sets
+        # defaults are algo salty and rooted
+        verfers, digers = mgr.incept(icount=3, ncount=3, stem='edy', temp=True)
+        sith = ["1/2", "1/2", "1/2"]  #  2 of 3 but with weighted threshold
+        nxtsith = ["1/2", "1/2", "1/2"]
+
+        srdr = eventing.incept(keys=[verfer.qb64 for verfer in verfers],
+                                  sith=sith,
+                                 nxt=coring.Nexter(sith=nxtsith,
+                                                   digs=[diger.qb64 for diger in digers]).qb64,
+                                 code=coring.CryOneDex.Blake3_256)
+
+        pre = srdr.ked["i"]
+        icpdig = srdr.dig
+
+        mgr.move(old=verfers[0].qb64, new=pre)  # move key pair label to prefix
+
+        sigers = mgr.sign(ser=srdr.raw, verfers=verfers)
+
+        msg = bytearray(srdr.raw)
+        counter = coring.SigCounter(count=len(sigers))
+        msg.extend(counter.qb64b)
+        for siger in sigers:
+            msg.extend(siger.qb64b)
+
+        icpmsg = msg
+
+        # create receipter (validator) inception keys 2 of 3
+        rverfers, rdigers = mgr.incept(icount=3, ncount=3, stem='ray', temp=True)
+        rsith = '2'
+
+        # create recepter's inception event
+        rsrdr = eventing.incept(keys=[verfer.qb64 for verfer in rverfers],
+                                sith=rsith,
+                                nxt=coring.Nexter(sith=rsith,
+                                                  digs=[diger.qb64 for diger in rdigers]).qb64,
+                                code=coring.CryOneDex.Blake3_256)
+
+        rpre = rsrdr.ked["i"]
+        ricpdig = rsrdr.dig
+
+        mgr.move(old=rverfers[0].qb64, new=rpre)  # move receipter key pair label to prefix
+
+        rsigers = mgr.sign(ser=rsrdr.raw, verfers=rverfers)
+
+        msg = bytearray(rsrdr.raw)
+        counter = coring.SigCounter(count=len(rsigers))
+        msg.extend(counter.qb64b)
+        for siger in rsigers:
+            msg.extend(siger.qb64b)
+
+        ricpmsg = msg
+
+
+        # create chit receipt(s) of inception message
+        seal = eventing.SealEvent(i=rpre,
+                                  s=rsrdr.sn,
+                                  d=rsrdr.dig)
+        reserder = eventing.chit(pre=pre, sn=0, dig=icpdig, seal=seal)
+        # sign event not receipt
+        resigers = mgr.sign(ser=srdr.raw, verfers=rverfers)
+        recnt = coring.CryCounter(count=len(resigers))
+
+        msg = bytearray()
+        msg.extend(reserder.raw)
+        msg.extend(recnt.qb64b)
+        for siger in resigers:
+            msg.extend(siger.qb64b)
+
+        rcticpmsg = msg
+
+        # Process receipt by kvy
+        kvy.processAll(ims=bytearray(rcticpmsg))  # process local copy of msg
+        assert pre not in kvy.kevers  # no events yet for pre  (receipted)
+        assert rpre not in kvy.kevers  # no events yet for rpre (receipter)
+
+        escrows = kvy.baser.getVres(dbing.snKey(pre, 0))  # so escrowed receipts
+        assert len(escrows) == 3
+        diger, sprefixer, sseqner, sdiger, siger = eventing.dequinlet(escrows[0])
+        assert diger.qb64 == srdr.dig
+        assert sprefixer.qb64 == rpre
+        assert sseqner.sn == 0
+        assert sdiger.qb64 == rsrdr.dig
+        assert siger.qb64 == resigers[0].qb64
+
+
+        # create interaction event
+        srdr = eventing.interact(pre=pre, dig=icpdig, sn=1, data=[])
+        ixndig = srdr.dig
+        sigers = mgr.sign(ser=srdr.raw, verfers=verfers)
+
+        msg = bytearray(srdr.raw)
+        counter = coring.SigCounter(count=len(sigers))
+        msg.extend(counter.qb64b)
+        for siger in sigers:
+            msg.extend(siger.qb64b)
+
+        ixnmsg = msg
+
+        # Create rotation event of receipter
+        # get current keys as verfers and next digests as digers
+        rverfers, rdigers = mgr.rotate(pre=rpre, count=3, temp=True)
+
+        rsrdr = eventing.rotate(pre=rpre,
+                                  keys=[verfer.qb64 for verfer in rverfers],
+                                  sith=rsith,
+                                  dig=ricpdig,
+                                  nxt=coring.Nexter(sith=rsith,
+                                                    digs=[diger.qb64 for diger in rdigers]).qb64,
+                                  sn=1,
+                                  data=[])
+
+        rrotdig = rsrdr.dig
+
+        rsigers = mgr.sign(ser=rsrdr.raw, verfers=rverfers)
+
+        msg = bytearray(rsrdr.raw)
+        counter = coring.SigCounter(count=len(rsigers))
+        msg.extend(counter.qb64b)
+        for siger in rsigers:
+            msg.extend(siger.qb64b)
+
+        rrotmsg = msg
+
+        # create receipt(s) of interaction message with receipter rotation message
+        # create chit receipt(s) of interaction message
+        seal = eventing.SealEvent(i=rpre,
+                                      s=rsrdr.sn,
+                                      d=rsrdr.dig)
+        reserder = eventing.chit(pre=pre, sn=1, dig=ixndig, seal=seal)
+        # sign event not receipt
+        resigers = mgr.sign(ser=srdr.raw, verfers=rverfers)
+        recnt = coring.CryCounter(count=len(resigers))
+
+
+        msg = bytearray()
+        msg.extend(reserder.raw)
+        msg.extend(recnt.qb64b)
+        for siger in resigers:
+            msg.extend(siger.qb64b)
+
+        rctixnmsg = msg
+
+        # Process receipt by kvy
+        kvy.processAll(ims=bytearray(rctixnmsg))  # process local copy of msg
+        assert pre not in kvy.kevers  # no events yet for pre
+        assert rpre not in kvy.kevers  # no events yet for rpre (receipter)
+
+        escrows = kvy.baser.getVres(dbing.snKey(pre, 1))  # so escrowed receipts
+        assert len(escrows) == 3
+        diger, sprefixer, sseqner, sdiger, siger = eventing.dequinlet(escrows[0])
+        assert diger.qb64 == srdr.dig
+        assert sprefixer.qb64 == rpre
+        assert sseqner.sn == 1
+        assert sdiger.qb64 == rsrdr.dig
+        assert siger.qb64 == resigers[0].qb64
+
+
+
+        # Create rotation event or receipted
+        # get current keys as verfers and next digests as digers
+        verfers, digers = mgr.rotate(pre=pre, count=5, temp=True)
+        sith = nxtsith  # rotate so nxtsith is now current sith and need new nextsith
+        #  2 of first 3 and 1 of last 2
+        nxtsith = [["1/2", "1/2", "1/2"],["1/1", "1/1"]]
+
+        srdr = eventing.rotate(pre=pre,
+                                  keys=[verfer.qb64 for verfer in verfers],
+                                  sith=sith,
+                                  dig=ixndig,
+                                  nxt=coring.Nexter(sith=nxtsith,
+                                                    digs=[diger.qb64 for diger in digers]).qb64,
+                                  sn=2,
+                                  data=[])
+
+        rotdig = srdr.dig
+
+        sigers = mgr.sign(ser=srdr.raw, verfers=verfers)
+
+        msg = bytearray(srdr.raw)
+        counter = coring.SigCounter(count=len(sigers))
+        msg.extend(counter.qb64b)
+        for siger in sigers:
+            msg.extend(siger.qb64b)
+
+        rotmsg = msg
+
+        # create receipt(s) of rotation message with rotation message of receipter
+        # create chit receipt(s) of interaction message
+        seal = eventing.SealEvent(i=rpre,
+                                      s=rsrdr.sn,
+                                      d=rsrdr.dig)
+        reserder = eventing.chit(pre=pre, sn=2, dig=rotdig, seal=seal)
+        # sign event not receipt
+        resigers = mgr.sign(ser=srdr.raw, verfers=rverfers)
+        recnt = coring.CryCounter(count=len(resigers))
+
+        msg = bytearray()
+        msg.extend(reserder.raw)
+        msg.extend(recnt.qb64b)
+        for siger in resigers:
+            msg.extend(siger.qb64b)
+
+        rctrotmsg = msg
+
+        # Process receipt by kvy
+        kvy.processAll(ims=bytearray(rctrotmsg))  # process local copy of msg
+        assert pre not in kvy.kevers  # no events yet for pre
+        assert rpre not in kvy.kevers  # no events yet for rpre (receipter)
+
+        escrows = kvy.baser.getVres(dbing.snKey(pre, 2))  # so escrowed receipts
+        assert len(escrows) == 3
+        diger, sprefixer, sseqner, sdiger, siger = eventing.dequinlet(escrows[0])
+        assert diger.qb64 == srdr.dig
+        assert sprefixer.qb64 == rpre
+        assert sseqner.sn == 1
+        assert sdiger.qb64 == rsrdr.dig
+        assert siger.qb64 == resigers[0].qb64
+
+        # Process out of unverified but stale escrow  set Timeout to 0
+        kvy.TimeoutVRE = 0  # forces all escrows to be stale
+        time.sleep(0.001)
+        kvy.processTransUnverifieds()
+        assert pre not in kvy.kevers  # key state not updated
+        assert rpre not in kvy.kevers  # key state not updated for receipter
+        # check escrows removed
+        assert len(kvy.baser.getVres(dbing.snKey(pre, 0))) == 0
+        assert len(kvy.baser.getVres(dbing.snKey(pre, 1))) == 0
+        assert len(kvy.baser.getVres(dbing.snKey(pre, 2))) == 0
+
+        # Now reset timeout so not zero and resend receipts to reload escrow
+        kvy.TimeoutVRE = 3600
+
+        # Process receipt by kvy
+        kvy.processAll(ims=bytearray(rcticpmsg))  # process local copy of msg
+        kvy.processAll(ims=bytearray(rctixnmsg))  # process local copy of msg
+        kvy.processAll(ims=bytearray(rctrotmsg))  # process local copy of msg
+        assert pre not in kvy.kevers  # no events yet for pre
+        assert rpre not in kvy.kevers  # no events yet for rpre (receipter)
+        # check escrows are back
+        assert len(kvy.baser.getVres(dbing.snKey(pre, 0))) == 3
+        assert len(kvy.baser.getVres(dbing.snKey(pre, 1))) == 3
+        assert len(kvy.baser.getVres(dbing.snKey(pre, 2))) == 3
+
+        # apply inception msg to Kevery to process
+        kvy.processAll(ims=bytearray(icpmsg))  # process local copy of msg
+        assert pre in kvy.kevers  # event accepted
+        kvr = kvy.kevers[pre]
+        assert kvr.serder.dig == icpdig  # key state updated so event was validated
+        assert kvr.sn == 0  # key state successfully updated
+
+        # apply ixn msg to Kevery to process
+        kvy.processAll(ims=bytearray(ixnmsg))  # process local copy of msg
+        assert kvr.serder.dig == ixndig  # key state updated so event was validated
+        assert kvr.sn == 1  # key state successfully updated
+
+        # apply rotation msg to Kevery to process
+        kvy.processAll(ims=bytearray(rotmsg))  # process local copy of msg
+        assert kvr.serder.dig == rotdig  # key state updated so event was validated
+        assert kvr.sn == 2  # key state successfully updated
+
+        # check escrows have not changed
+        assert len(kvy.baser.getVres(dbing.snKey(pre, 0))) == 3
+        assert len(kvy.baser.getVres(dbing.snKey(pre, 1))) == 3
+        assert len(kvy.baser.getVres(dbing.snKey(pre, 2))) == 3
+
+        # verify Kevery process unverified trans receipt escrow
+        kvy.processTransUnverifieds()
+        # check escrows have not changed because no receipter events
+        assert len(kvy.baser.getVres(dbing.snKey(pre, 0))) == 3
+        assert len(kvy.baser.getVres(dbing.snKey(pre, 1))) == 3
+        assert len(kvy.baser.getVres(dbing.snKey(pre, 2))) == 3
+
+        # apply inception msg of receipter to Kevery to process
+        kvy.processAll(ims=bytearray(ricpmsg))  # process local copy of msg
+        assert rpre in kvy.kevers  # rpre (receipter) accepted
+        rkvr = kvy.kevers[rpre]
+        assert rkvr.serder.dig == ricpdig  # key state updated so event was validated
+        assert rkvr.sn == 0  # key state successfully updated
+
+        # verify Kevery process unverified trans receipt escrow
+        kvy.processTransUnverifieds()
+        # check escrows have changed for receipts by receipter inception
+        assert len(kvy.baser.getVres(dbing.snKey(pre, 0))) == 0
+        assert len(kvy.baser.getVres(dbing.snKey(pre, 1))) == 3
+        assert len(kvy.baser.getVres(dbing.snKey(pre, 2))) == 3
+
+        # apply rotation msg of receipter to Kevery to process
+        kvy.processAll(ims=bytearray(rrotmsg))  # process local copy of msg
+        assert rkvr.serder.dig == rrotdig  # key state updated so event was validated
+        assert rkvr.sn == 1  # key state successfully updated
+
+        # verify Kevery process unverified trans receipt escrow
+        kvy.processTransUnverifieds()
+        # check escrows have changed for receipts by receipter inception
+        assert len(kvy.baser.getVres(dbing.snKey(pre, 0))) == 0
+        assert len(kvy.baser.getVres(dbing.snKey(pre, 1))) == 0
+        assert len(kvy.baser.getVres(dbing.snKey(pre, 2))) == 0
+
+        # verify receipts
+        receipts = kvy.baser.getRcts(dbing.dgKey(pre, icpdig))
+        assert len(receipts) == 2
+        rctPrefixer, rctCigar = eventing.decouplet(receipts[0])
+        assert rctPrefixer.qb64 == wit0pre
+        rctPrefixer, rctCigar = eventing.decouplet(receipts[1])
+        assert rctPrefixer.qb64 == wit1pre
+        receipts = kvy.baser.getRcts(dbing.dgKey(pre, ixndig))
+        assert len(receipts) == 2
+        rctPrefixer, rctCigar = eventing.decouplet(receipts[0])
+        assert rctPrefixer.qb64 == wit0pre
+        rctPrefixer, rctCigar = eventing.decouplet(receipts[1])
+        assert rctPrefixer.qb64 == wit1pre
+        receipts = kvy.baser.getRcts(dbing.dgKey(pre, rotdig))
+        assert len(receipts) == 2
+        rctPrefixer, rctCigar = eventing.decouplet(receipts[0])
+        assert rctPrefixer.qb64 == wit0pre
+        rctPrefixer, rctCigar = eventing.decouplet(receipts[1])
+        assert rctPrefixer.qb64 == wit1pre
+
+
+    assert not os.path.exists(kpr.path)
+    assert not os.path.exists(db.path)
+
+    """End Test"""
+
+
 if __name__ == "__main__":
-    test_unverified_receipt_escrow()
+    test_unverified_trans_receipt_escrow()
 

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -407,7 +407,7 @@ def test_kever():
 
 
         # Derive AID from ked
-        aid0 = Prefixer(ked=ked0, code = CryOneDex.Ed25519)
+        aid0 = Prefixer(ked=ked0, code=CryOneDex.Ed25519)
         assert aid0.code == CryOneDex.Ed25519
         assert aid0.qb64 == skp0.verfer.qb64
 
@@ -463,7 +463,7 @@ def test_kever():
 
         # Derive AID from ked
         with pytest.raises(DerivationError):
-            aid0 = Prefixer(ked=ked0, code = CryOneDex.Ed25519N)
+            aid0 = Prefixer(ked=ked0, code=CryOneDex.Ed25519N)
 
         # assert aid0.code == CryOneDex.Ed25519N
         # assert aid0.qb64 == skp0.verfer.qb64
@@ -1590,7 +1590,7 @@ def test_receipt():
 
     # create receipt signer prefixer  default code is non-transferable
     valSigner = Signer(qb64=valSecrets[0], transferable=False)
-    valPrefixer = Prefixer(qb64=valSigner.verfer.qb64, )
+    valPrefixer = Prefixer(qb64=valSigner.verfer.qb64)
     assert valPrefixer.code == CryOneDex.Ed25519N
     valpre = valPrefixer.qb64
     assert valpre == 'B8KY1sKmgyjAiUDdUBPNPyrSz_ad_Qf9yzhDNZlEKiMc'
@@ -2890,7 +2890,7 @@ def test_process_nontransferable():
         del msgb0[:len(rsig.qb64)]
 
     # verify pre
-    raid0 = Prefixer(qb64=rser0.ked["i"])
+    raid0 = Prefixer(qb64=rser0.pre)
     assert raid0.verify(ked=rser0.ked)
     """ Done Test """
 
@@ -2980,7 +2980,7 @@ def test_process_transferable():
         del msgb0[:len(rsig.qb64)]
 
     # verify pre
-    raid0 = Prefixer(qb64=rser0.ked["i"])
+    raid0 = Prefixer(qb64=rser0.pre)
     assert raid0.verify(ked=rser0.ked)
 
     #verify nxt digest from event is still valid

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -2102,9 +2102,10 @@ def test_direct_mode():
 
         coeKevery.processAll(ims=vmsg)  #  coe process the escrow receipt from val
         #  check if receipt quadlet in escrow database
-        result = coeKevery.baser.getVres(key=dgKey(pre=coeKever.prefixer.qb64,
-                                                   dig=fake))
-        assert bytes(result[0]) == (valKever.prefixer.qb64b +
+        result = coeKevery.baser.getVres(key=snKey(pre=coeKever.prefixer.qb64,
+                                                   sn=10))
+        assert bytes(result[0]) == (fake.encode("utf-8") +
+                                    valKever.prefixer.qb64b +
                                     Seqner(sn=valKever.sn).qb64b +
                                     valKever.serder.diger.qb64b +
                                     siger.qb64b)
@@ -2377,6 +2378,7 @@ def test_direct_mode():
 
     """ Done Test """
 
+
 def test_direct_mode_cbor_mgpk():
     """
     Test direct mode with transverable validator event receipts but using
@@ -2592,12 +2594,14 @@ def test_direct_mode_cbor_mgpk():
 
         coeKevery.processAll(ims=vmsg)  #  coe process the escrow receipt from val
         #  check if in escrow database
-        result = coeKevery.baser.getVres(key=dgKey(pre=coeKever.prefixer.qb64,
-                                                   dig=fake))
-        assert bytes(result[0]) == (valKever.prefixer.qb64b +
-                                    Seqner(sn=valKever.sn).qb64b +
-                                    valKever.serder.diger.qb64b +
-                                    siger.qb64b)
+        result = coeKevery.baser.getVres(key=snKey(pre=coeKever.prefixer.qb64,
+                                                       sn=10))
+        assert bytes(result[0]) == (fake.encode("utf-8") +
+                                        valKever.prefixer.qb64b +
+                                        Seqner(sn=valKever.sn).qb64b +
+                                        valKever.serder.diger.qb64b +
+                                        siger.qb64b)
+
 
         # Send receipt from coe to val
         # create receipt of val's inception
@@ -3168,4 +3172,4 @@ def test_process_manual():
 
 
 if __name__ == "__main__":
-    test_dequinlet()
+    test_direct_mode_cbor_mgpk()

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -32,7 +32,8 @@ from keri.core.coring import Versify, Deversify, Rever
 from keri.core.coring import Serder
 from keri.core.coring import Ilkage, Ilks
 
-from keri.core.eventing import TraitDex, LastEstLoc, decouplet, detriplet, dequinlet
+from keri.core.eventing import TraitDex, LastEstLoc
+from keri.core.eventing import decouplet, detriplet, dequadlet, dequinlet
 from keri.core.eventing import SealDigest, SealRoot, SealEvent, SealLocation
 from keri.core.eventing import (incept, rotate, interact, receipt, chit,
                                 delcept, deltate)
@@ -109,12 +110,50 @@ def test_detriplet():
 
     """end test"""
 
+def test_dequadlet():
+    """
+    test test_dequadlet function
+    """
+    spre = 'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA'
+    ssnu = '0AAAAAAAAAAAAAAAAAAAAABQ'
+    sdig = 'EsLkveIFUPvt38xhtgYYJRCCpAGO7WjjHVR37Pawv67E'
+    sig = 'AFmdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ'
+
+    quadlet = spre + ssnu + sdig + sig
+    sprefixer, sseqner, sdiger, siger = dequadlet(quadlet)
+    assert sprefixer.qb64 == spre
+    assert sseqner.qb64 == ssnu
+    assert sdiger.qb64 == sdig
+    assert siger.qb64 == sig
+
+    # bytes
+    spre = b'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA'
+    ssnu = b'0AAAAAAAAAAAAAAAAAAAAABQ'
+    sdig = b'EsLkveIFUPvt38xhtgYYJRCCpAGO7WjjHVR37Pawv67E'
+    sig = b'AFmdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ'
+
+    quadlet = spre + ssnu + sdig + sig
+    sprefixer, sseqner, sdiger, sigar = dequadlet(quadlet)
+    assert sprefixer.qb64b == spre
+    assert sseqner.qb64b == ssnu
+    assert sdiger.qb64b == sdig
+    assert siger.qb64b == sig
+
+
+    quadlet = memoryview(quadlet)
+    quadlet = spre + ssnu + sdig + sig
+    sprefixer, sseqner, sdiger, sigar = dequadlet(quadlet)
+    assert sprefixer.qb64b == spre
+    assert sseqner.qb64b == ssnu
+    assert sdiger.qb64b == sdig
+    assert siger.qb64b == sig
+
+    """end test"""
+
 
 def test_dequinlet():
     """
     test dequinlet function
-
-    Something wrong with test
     """
     edig = 'E62X8Lfrl9lZbCGz8cfKIvM_cqLyTYVLSFLhnttezlzQ'
     spre = 'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA'
@@ -3172,4 +3211,4 @@ def test_process_manual():
 
 
 if __name__ == "__main__":
-    test_direct_mode()
+    test_dequadlet()

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -3117,4 +3117,4 @@ def test_process_manual():
 
 
 if __name__ == "__main__":
-    test_detriplet()
+    test_direct_mode()

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -18,7 +18,7 @@ from keri.kering import (ValidationError, EmptyMaterialError, DerivationError,
 from keri.core.coring import CrySelDex, CryOneDex, CryTwoDex, CryFourDex
 from keri.core.coring import CryOneSizes, CryOneRawSizes, CryTwoSizes, CryTwoRawSizes
 from keri.core.coring import CryFourSizes, CryFourRawSizes, CrySizes, CryRawSizes
-from keri.core.coring import CryMat, CryCounter, SeqNumber
+from keri.core.coring import CryMat, CryCounter, Seqner
 from keri.core.coring import Verfer, Signer, Diger, Nexter, Prefixer
 from keri.core.coring import generateSigners, generateSecrets
 from keri.core.coring import SigSelDex, SigTwoDex, SigTwoSizes, SigTwoRawSizes
@@ -2020,7 +2020,7 @@ def test_direct_mode():
         result = coeKevery.baser.getVrcs(key=dgKey(pre=coeKever.prefixer.qb64,
                                                     dig=coeKever.serder.diger.qb64))
         assert bytes(result[0]) == (valKever.prefixer.qb64b +
-                                    SeqNumber(sn=valKever.sn).qb64b +
+                                    Seqner(sn=valKever.sn).qb64b +
                                     valKever.serder.diger.qb64b +
                                     siger.qb64b)
         assert bytes(result[0]) == (b'EpDA1n-WiBA0A8YOqnKrB-wWQYYC49i5zY_qrIZIicQg0AAAAAAAAAAAAAAAAAAAAAAAEGFSGYH2'
@@ -2054,7 +2054,7 @@ def test_direct_mode():
         result = coeKevery.baser.getVres(key=dgKey(pre=coeKever.prefixer.qb64,
                                                    dig=fake))
         assert bytes(result[0]) == (valKever.prefixer.qb64b +
-                                    SeqNumber(sn=valKever.sn).qb64b +
+                                    Seqner(sn=valKever.sn).qb64b +
                                     valKever.serder.diger.qb64b +
                                     siger.qb64b)
 
@@ -2107,7 +2107,7 @@ def test_direct_mode():
         result = valKevery.baser.getVrcs(key=dgKey(pre=valKever.prefixer.qb64,
                                                     dig=valKever.serder.diger.qb64))
         assert bytes(result[0]) == (coeKever.prefixer.qb64b +
-                                    SeqNumber(sn=coeKever.sn).qb64b +
+                                    Seqner(sn=coeKever.sn).qb64b +
                                     coeKever.serder.diger.qb64b +
                                     siger.qb64b)
         assert bytes(result[0]) == (b'EH7Oq9oxCgYa-nnNLvwhp9sFZpALILlRYyB-6n4WDi7w0AAAAAAAAAAAAAAAAAAAAAAAEEnwxEm5'
@@ -2198,7 +2198,7 @@ def test_direct_mode():
         result = coeKevery.baser.getVrcs(key=dgKey(pre=coeKever.prefixer.qb64,
                                                         dig=coeKever.serder.diger.qb64))
         assert bytes(result[0]) == (valKever.prefixer.qb64b +
-                                    SeqNumber(sn=valKever.sn).qb64b +
+                                    Seqner(sn=valKever.sn).qb64b +
                                     valKever.serder.diger.qb64b +
                                     siger.qb64b)
 
@@ -2285,7 +2285,7 @@ def test_direct_mode():
         result = coeKevery.baser.getVrcs(key=dgKey(pre=coeKever.prefixer.qb64,
                                                         dig=coeKever.serder.diger.qb64))
         assert bytes(result[0]) == (valKever.prefixer.qb64b +
-                                    SeqNumber(sn=valKever.sn).qb64b +
+                                    Seqner(sn=valKever.sn).qb64b +
                                     valKever.serder.diger.qb64b +
                                     siger.qb64b)
 
@@ -2510,7 +2510,7 @@ def test_direct_mode_cbor_mgpk():
         result = coeKevery.baser.getVrcs(key=dgKey(pre=coeKever.prefixer.qb64,
                                                     dig=coeKever.serder.diger.qb64))
         assert bytes(result[0]) == (valKever.prefixer.qb64b +
-                                    SeqNumber(sn=valKever.sn).qb64b +
+                                    Seqner(sn=valKever.sn).qb64b +
                                     valKever.serder.diger.qb64b +
                                     siger.qb64b)
         assert bytes(result[0]) == (b'E-5yGMmTDo6Qkr4G36Jy91gz5bF2y_Ef-s_S0jIfaoOY0AAAAAAAAAAAAAAAAAAAAAAAEHJmsEzp'
@@ -2544,7 +2544,7 @@ def test_direct_mode_cbor_mgpk():
         result = coeKevery.baser.getVres(key=dgKey(pre=coeKever.prefixer.qb64,
                                                    dig=fake))
         assert bytes(result[0]) == (valKever.prefixer.qb64b +
-                                    SeqNumber(sn=valKever.sn).qb64b +
+                                    Seqner(sn=valKever.sn).qb64b +
                                     valKever.serder.diger.qb64b +
                                     siger.qb64b)
 
@@ -2595,7 +2595,7 @@ def test_direct_mode_cbor_mgpk():
         result = valKevery.baser.getVrcs(key=dgKey(pre=valKever.prefixer.qb64,
                                                     dig=valKever.serder.diger.qb64))
         assert bytes(result[0]) == (coeKever.prefixer.qb64b +
-                                    SeqNumber(sn=coeKever.sn).qb64b +
+                                    Seqner(sn=coeKever.sn).qb64b +
                                     coeKever.serder.diger.qb64b +
                                     siger.qb64b)
         assert bytes(result[0]) == (b'EMejbZsIeOI5TTb73MKIVbjkYFURM8iREGeX5CyaxJvU0AAAAAAAAAAAAAAAAAAAAAAAEyAyl33W'
@@ -2687,7 +2687,7 @@ def test_direct_mode_cbor_mgpk():
         result = coeKevery.baser.getVrcs(key=dgKey(pre=coeKever.prefixer.qb64,
                                                         dig=coeKever.serder.diger.qb64))
         assert bytes(result[0]) == (valKever.prefixer.qb64b +
-                                    SeqNumber(sn=valKever.sn).qb64b +
+                                    Seqner(sn=valKever.sn).qb64b +
                                     valKever.serder.diger.qb64b +
                                     siger.qb64b)
 
@@ -2774,7 +2774,7 @@ def test_direct_mode_cbor_mgpk():
         result = coeKevery.baser.getVrcs(key=dgKey(pre=coeKever.prefixer.qb64,
                                                         dig=coeKever.serder.diger.qb64))
         assert bytes(result[0]) == (valKever.prefixer.qb64b +
-                                    SeqNumber(sn=valKever.sn).qb64b +
+                                    Seqner(sn=valKever.sn).qb64b +
                                     valKever.serder.diger.qb64b +
                                     siger.qb64b)
 

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -3172,4 +3172,4 @@ def test_process_manual():
 
 
 if __name__ == "__main__":
-    test_direct_mode_cbor_mgpk()
+    test_direct_mode()

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -32,7 +32,7 @@ from keri.core.coring import Versify, Deversify, Rever
 from keri.core.coring import Serder
 from keri.core.coring import Ilkage, Ilks
 
-from keri.core.eventing import TraitDex, LastEstLoc, detriplet, decouplet
+from keri.core.eventing import TraitDex, LastEstLoc, decouplet, detriplet, dequinlet
 from keri.core.eventing import SealDigest, SealRoot, SealEvent, SealLocation
 from keri.core.eventing import (incept, rotate, interact, receipt, chit,
                                 delcept, deltate)
@@ -43,6 +43,36 @@ from keri.db.dbing import dgKey, snKey, openDB, Baser
 from keri.help import ogling
 
 blogger, flogger = ogling.ogler.getLoggers()
+
+
+
+def test_decouplet():
+    """
+    test decouplet function
+    """
+    pre = 'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA'
+    sig = '0BMszieX0cpTOWZwa2I2LfeFAi9lrDjc1-Ip9ywl1KCNqie4ds_3mrZxHFboMC8Fu_5asnM7m67KlGC9EYaw0KDQ'
+
+    couplet = pre + sig
+    prefixer, cigar = decouplet(couplet)
+    assert prefixer.qb64 == pre
+    assert cigar.qb64 == sig
+
+    # bytes
+    pre = b'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA'
+    sig = b'0BMszieX0cpTOWZwa2I2LfeFAi9lrDjc1-Ip9ywl1KCNqie4ds_3mrZxHFboMC8Fu_5asnM7m67KlGC9EYaw0KDQ'
+
+    couplet = pre + sig
+    prefixer, cigar = decouplet(couplet)
+    assert prefixer.qb64b == pre
+    assert cigar.qb64b == sig
+
+    couplet = memoryview(couplet)
+    prefixer, cigar = decouplet(couplet)
+    assert prefixer.qb64b == pre
+    assert cigar.qb64b == sig
+
+    """end test"""
 
 
 def test_detriplet():
@@ -79,31 +109,52 @@ def test_detriplet():
 
     """end test"""
 
-def test_decouplet():
-    """
-    test decouplet function
-    """
-    pre = 'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA'
-    sig = '0BMszieX0cpTOWZwa2I2LfeFAi9lrDjc1-Ip9ywl1KCNqie4ds_3mrZxHFboMC8Fu_5asnM7m67KlGC9EYaw0KDQ'
 
-    couplet = pre + sig
-    prefixer, cigar = decouplet(couplet)
-    assert prefixer.qb64 == pre
-    assert cigar.qb64 == sig
+def test_dequinlet():
+    """
+    test dequinlet function
+
+    Something wrong with test
+    """
+    edig = 'E62X8Lfrl9lZbCGz8cfKIvM_cqLyTYVLSFLhnttezlzQ'
+    spre = 'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA'
+    ssnu = '0AAAAAAAAAAAAAAAAAAAAABQ'
+    sdig = 'EsLkveIFUPvt38xhtgYYJRCCpAGO7WjjHVR37Pawv67E'
+    sig = 'AFmdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ'
+
+    sealet = spre + ssnu + sdig
+    quinlet = edig + sealet + sig
+    ediger, sprefixer, sseqner, sdiger, siger = dequinlet(quinlet)
+    assert ediger.qb64 == edig
+    assert sprefixer.qb64 == spre
+    assert sseqner.qb64 == ssnu
+    assert sdiger.qb64 == sdig
+    assert siger.qb64 == sig
 
     # bytes
-    pre = b'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA'
-    sig = b'0BMszieX0cpTOWZwa2I2LfeFAi9lrDjc1-Ip9ywl1KCNqie4ds_3mrZxHFboMC8Fu_5asnM7m67KlGC9EYaw0KDQ'
+    edig = b'E62X8Lfrl9lZbCGz8cfKIvM_cqLyTYVLSFLhnttezlzQ'
+    spre = b'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA'
+    ssnu = b'0AAAAAAAAAAAAAAAAAAAAABQ'
+    sdig = b'EsLkveIFUPvt38xhtgYYJRCCpAGO7WjjHVR37Pawv67E'
+    sig = b'AFmdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ'
 
-    couplet = pre + sig
-    prefixer, cigar = decouplet(couplet)
-    assert prefixer.qb64b == pre
-    assert cigar.qb64b == sig
+    quinlet = edig + spre + ssnu + sdig + sig
+    ediger, sprefixer, sseqner, sdiger, sigar = dequinlet(quinlet)
+    assert ediger.qb64b == edig
+    assert sprefixer.qb64b == spre
+    assert sseqner.qb64b == ssnu
+    assert sdiger.qb64b == sdig
+    assert siger.qb64b == sig
 
-    couplet = memoryview(couplet)
-    prefixer, cigar = decouplet(couplet)
-    assert prefixer.qb64b == pre
-    assert cigar.qb64b == sig
+
+    quinlet = memoryview(quinlet)
+    quinlet = edig + spre + ssnu + sdig + sig
+    ediger, sprefixer, sseqner, sdiger, sigar = dequinlet(quinlet)
+    assert ediger.qb64b == edig
+    assert sprefixer.qb64b == spre
+    assert sseqner.qb64b == ssnu
+    assert sdiger.qb64b == sdig
+    assert siger.qb64b == sig
 
     """end test"""
 
@@ -3117,4 +3168,4 @@ def test_process_manual():
 
 
 if __name__ == "__main__":
-    test_direct_mode()
+    test_dequinlet()


### PR DESCRIPTION
Refactoring clean up of code. Fixes to receipting logic and escrow logic. Now processes correctly with tests.