### PR TITLE
Redirect  nontrans receipt couples when witnesses of receipted event …

### DIFF
--- a/tests/core/test_escrow.py
+++ b/tests/core/test_escrow.py
@@ -1358,5 +1358,5 @@ def test_unverified_trans_receipt_escrow():
 
 
 if __name__ == "__main__":
-    test_partial_signed_escrow()
+    test_unverified_receipt_escrow()
 


### PR DESCRIPTION
…to .wigs

instead of .rcts to allow either attachment type to work for witness receipts. This backwards compatible and
more flexible in future.