### PR TITLE
Implementation of KOM

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ Best practices for setup.py and requirements.txt
 https://caremad.io/posts/2013/07/setup-vs-requirement/
 """
 
-
 from glob import glob
 from os.path import basename
 from os.path import splitext
@@ -32,11 +31,9 @@ from os.path import splitext
 from setuptools import find_packages
 from setuptools import setup
 
-
-
 setup(
     name='keri',
-    version='0.4.3',  #  also change in src/keri/__init__.py
+    version='0.4.3',  # also change in src/keri/__init__.py
     license='Apache Software License 2.0',
     description='Key Event Receipt Infrastructure',
     long_description="KERI Decentralized Key Management Infrastructure",
@@ -59,7 +56,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         # uncomment if you test on these interpreters:
-        #'Programming Language :: Python :: Implementation :: PyPy',
+        # 'Programming Language :: Python :: Implementation :: PyPy',
         # 'Programming Language :: Python :: Implementation :: IronPython',
         # 'Programming Language :: Python :: Implementation :: Jython',
         # 'Programming Language :: Python :: Implementation :: Stackless',
@@ -86,10 +83,8 @@ setup(
 
     ],
     extras_require={
-        # eg:
-        #   'rst': ['docutils>=0.11'],
-        #   ':python_version=="2.6"': ['argparse'],
     },
+    tests_require=['coverage>=5.5', 'pytest>=6.2.4'],
     setup_requires=[
     ],
     entry_points={

--- a/src/keri/base/basing.py
+++ b/src/keri/base/basing.py
@@ -6,33 +6,40 @@ Support for application data via an LMDB keyspace object mapper (KOM)
 """
 
 import json
+from dataclasses import dataclass, asdict
+from typing import Type
+
+import cbor2
 import msgpack
 
-from typing import Type
-from dataclasses import dataclass, asdict, field
-
-from ..help import helping
+from ..core.coring import Serials
 from ..db import dbing
+from ..help import helping
 
 
-class Komer():
+class Komer:
     """
     Keyspace Object Mapper factory class
     """
+
     def __init__(self,
                  db: Type[dbing.LMDBer],
                  schema: Type[dataclass],
-                 subdb: str='docs.',
-                 kind: str='JSON'):
+                 subdb: str = 'docs.',
+                 kind: str = Serials.json):
         """
         Parameters:
+            db (dbing.LMDBer): base db
             schema (dataclass):  reference to Class definition for dataclass sub class
             subdb (str):  LMDB sub database key
+            kind (str): serialization/deserialization type
         """
         self.db = db
         self.schema = schema
         self.sdb = self.db.env.open_db(key=subdb.encode("utf-8"))
         self.kind = kind
+        self.serializer = self._serializer(kind)
+        self.deserializer = self._deserializer(kind)
 
     def put(self, keys: tuple, data: dataclass):
         """
@@ -42,7 +49,94 @@ class Komer():
         """
         if not isinstance(data, self.schema):
             raise ValueError("Invalid schema type={} of data={}, expected {}."
-                                   "".format(type(data), data, self.schema))
+                             "".format(type(data), data, self.schema))
+
         self.db.putVal(db=self.sdb,
                        key=":".join(keys).encode("utf-8"),
-                       val=json.dumps(asdict(data)).encode("utf-8") )
+                       val=self.serializer(data))
+
+    def get(self, keys: tuple):
+        """
+        Parameters:
+            keys (tuple): of key strs to be combined in order to form key
+        """
+
+        data = helping.datify(self.schema, self.deserializer(self.db.getVal(db=self.sdb,
+                                                                            key=":".join(keys).encode("utf-8"))))
+
+        if data is None:
+            return
+
+        if not isinstance(data, self.schema):
+            raise ValueError("Invalid schema type={} of data={}, expected {}."
+                             "".format(type(data), data, self.schema))
+
+        return data
+
+    def rem(self, keys: tuple):
+        """
+        Parameters:
+            keys (tuple): of key strs to be combined in order to form key
+        """
+        self.db.delVal(db=self.sdb,
+                       key=":".join(keys).encode("utf-8"))
+
+    def _serializer(self, kind):
+        """
+        Parameters:
+            kind (str): serialization
+        """
+        if kind == Serials.mgpk:
+            return self.__serializeMGPK
+        elif kind == Serials.cbor:
+            return self.__serializeCBOR
+        else:
+            return self.__serializeJSON
+
+    def _deserializer(self, kind):
+        """
+        Parameters:
+            kind (str): deserialization
+        """
+        if kind == Serials.mgpk:
+            return self.__deserializeMGPK
+        elif kind == Serials.cbor:
+            return self.__deserializeCBOR
+        else:
+            return self.__deserializeJSON
+
+    @staticmethod
+    def __deserializeJSON(val):
+        if val is None:
+            return
+        return json.loads(bytes(val).decode("utf-8"))
+
+    @staticmethod
+    def __deserializeMGPK(val):
+        if val is None:
+            return
+        return msgpack.loads(bytes(val))
+
+    @staticmethod
+    def __deserializeCBOR(val):
+        if val is None:
+            return
+        return cbor2.loads(bytes(val))
+
+    @staticmethod
+    def __serializeJSON(val):
+        if val is None:
+            return
+        return json.dumps(asdict(val)).encode("utf-8")
+
+    @staticmethod
+    def __serializeMGPK(val):
+        if val is None:
+            return
+        return msgpack.dumps(asdict(val))
+
+    @staticmethod
+    def __serializeCBOR(val):
+        if val is None:
+            return
+        return cbor2.dumps(asdict(val))

--- a/src/keri/help/helping.py
+++ b/src/keri/help/helping.py
@@ -3,19 +3,15 @@
 keri.help.helping module
 
 """
-import os
-import shutil
-import tempfile
 import base64
-import datetime
 import dataclasses
-
-from collections.abc import Iterable, Sequence,  Mapping
+import datetime
+from collections.abc import Iterable, Sequence, Mapping
 
 import pysodium
-
 from multidict import MultiDict  # base class for mdict defined below
 from orderedset import OrderedSet as oset
+
 
 # Utilities
 def isign(i):
@@ -139,7 +135,6 @@ class mdict(MultiDict):
             else:
                 return kwa["default"]
 
-
     def nab(self, key, *pa, **kwa):
         """
         Usage:
@@ -177,7 +172,6 @@ class mdict(MultiDict):
             else:
                 return kwa["default"]
 
-
     def firsts(self):
         """
         Returns list of (key, value) pair where each value is first value at key
@@ -187,7 +181,6 @@ class mdict(MultiDict):
         """
         keys = oset(self.keys())  # get rid of duplicates provided by .keys()
         return [(k, self.getone(k)) for k in keys]
-
 
     def lasts(self):
         """
@@ -220,8 +213,7 @@ def nonStringSequence(obj):
     for non string sequences.
 
     """
-    return (not isinstance(obj, (str, bytes)) and isinstance(obj, Sequence) )
-
+    return (not isinstance(obj, (str, bytes)) and isinstance(obj, Sequence))
 
 
 def extractElementValues(element, values):
@@ -259,6 +251,7 @@ def extractElementValues(element, values):
         raise ValueError("Unexpected element value = {}. Not a str.".format(element))
 
     return
+
 
 def extractValues(ked, labels):
     """
@@ -305,7 +298,7 @@ def toIso8601(dt=None):
     if dt is None:
         dt = datetime.datetime.now(datetime.timezone.utc)  # make it aware
 
-    return(dt.isoformat())
+    return (dt.isoformat())
 
 
 def fromIso8601(dts):

--- a/tests/base/test_basing.py
+++ b/tests/base/test_basing.py
@@ -1,33 +1,34 @@
 # -*- encoding: utf-8 -*-
 """
-tests.db.dbing module
+tests.base.basing module
 
 """
-import pytest
-
-import os
-from dataclasses import dataclass, asdict, field
 
 import json
+import os
+from dataclasses import dataclass, asdict
+
+import pytest
 
 from keri.base import basing
+from keri.core.coring import Serials
 from keri.db import dbing
 from keri.help import helping
 
-def test_komer():
+
+def test_happy_path():
     """
     Test Komer object class
     """
 
-
     @dataclass
-    class Record():
+    class Record:
         first: str  # first name
-        last: str   # last name
+        last: str  # last name
         street: str  # street address
-        city: str   # city name
+        city: str  # city name
         state: str  # state code
-        zip: int    # zip code
+        zip: int  # zip code
 
         def __iter__(self):
             return iter(asdict(self))
@@ -58,15 +59,161 @@ def test_komer():
                      state="UT",
                      zip=84058)
 
-        mydb.put(keys=("skskjgoshkdh","0001"), data=sue)
+        keys = ("test_key", "0001")
+        mydb.put(keys=keys, data=sue)
+        actual = mydb.get(keys=keys)
 
+        assert actual.first == "Susan"
+        assert actual.last == "Black"
+        assert actual.street == "100 Main Street"
+        assert actual.city == "Riverton"
+        assert actual.state == "UT"
+        assert actual.zip == 84058
 
+        mydb.rem(keys)
 
+        actual = mydb.get(keys=keys)
+        assert actual is None
 
     assert not os.path.exists(db.path)
     assert not db.opened
 
 
-if __name__ == "__main__":
-    test_komer()
+def test_put_invalid_dataclass():
+    @dataclass
+    class Record:
+        first: str
 
+        def __iter__(self):
+            return iter(asdict(self))
+
+    @dataclass
+    class AnotherClass:
+        age: int
+
+    with dbing.openLMDB() as db:
+        mydb = basing.Komer(db=db, schema=AnotherClass, subdb='records.')
+        sue = Record(first="Susan")
+        keys = ("test_key", "0001")
+
+        with pytest.raises(ValueError):
+            mydb.put(keys=keys, data=sue)
+
+
+def test_get_invalid_dataclass():
+    @dataclass
+    class Record:
+        first: str
+
+        def __iter__(self):
+            return iter(asdict(self))
+
+    @dataclass
+    class AnotherClass:
+        age: int
+
+    with dbing.openLMDB() as db:
+        mydb = basing.Komer(db=db, schema=Record, subdb='records.')
+        sue = Record(first="Susan")
+        keys = ("test_key", "0001")
+        mydb.put(keys=keys, data=sue)
+
+        mydb = basing.Komer(db=db, schema=AnotherClass, subdb='records.')
+        with pytest.raises(ValueError):
+            mydb.get(keys)
+
+
+def test_not_found_entity():
+    @dataclass
+    class Record:
+        first: str
+
+        def __iter__(self):
+            return iter(asdict(self))
+
+    with dbing.openLMDB() as db:
+        mydb = basing.Komer(db=db, schema=Record, subdb='records.')
+        sue = Record(first="Susan")
+        keys = ("test_key", "0001")
+
+        mydb.put(keys=keys, data=sue)
+        actual = mydb.get(("not_found", "0001"))
+        assert actual is None
+
+
+def test_serialization():
+    @dataclass
+    class Record:
+        first: str  # first name
+        last: str  # last name
+        street: str  # street address
+        city: str  # city name
+        state: str  # state code
+        zip: int  # zip code
+
+    jim = Record(first="Jim",
+                 last="Black",
+                 street="100 Main Street",
+                 city="Riverton",
+                 state="UT",
+                 zip=84058)
+
+    with dbing.openLMDB() as db:
+        k = basing.Komer(db=db, schema=Record, subdb='records.')
+        srl = k._serializer(Serials.mgpk)
+
+        expected = b'\x86\xa5first\xa3Jim\xa4last\xa5Black\xa6street\xaf100 Main Street\xa4city\xa8Riverton\xa5state\xa2UT\xa3zip\xce\x00\x01HZ'
+        assert srl(jim) == expected
+
+        srl = k._serializer(Serials.cbor)
+        expected = b'\xa6efirstcJimdlasteBlackfstreeto100 Main StreetdcityhRivertonestatebUTczip\x1a\x00\x01HZ'
+        assert srl(jim) == expected
+
+        srl = k._serializer(Serials.json)
+        expected = b'{"first": "Jim", "last": "Black", "street": "100 Main Street", "city": "Riverton", "state": "UT", "zip": 84058}'
+        assert srl(jim) == expected
+
+
+def test_deserialization():
+    @dataclass
+    class Record:
+        first: str  # first name
+        last: str  # last name
+        street: str  # street address
+        city: str  # city name
+        state: str  # state code
+        zip: int  # zip code
+
+    msgp = b'\x86\xa5first\xa3Jim\xa4last\xa5Black\xa6street\xaf100 Main Street\xa4city\xa8Riverton\xa5state\xa2UT\xa3zip\xce\x00\x01HZ'
+    cbor = b'\xa6efirstcJimdlasteBlackfstreeto100 Main StreetdcityhRivertonestatebUTczip\x1a\x00\x01HZ'
+    json = b'{"first": "Jim", "last": "Black", "street": "100 Main Street", "city": "Riverton", "state": "UT", "zip": 84058}'
+
+    with dbing.openLMDB() as db:
+        k = basing.Komer(db=db, schema=Record, subdb='records.')
+
+        desrl = k._deserializer(Serials.mgpk)
+        actual = helping.datify(Record, desrl(msgp))
+        assert actual.first == "Jim"
+        assert actual.last == "Black"
+        assert actual.street == "100 Main Street"
+        assert actual.city == "Riverton"
+        assert actual.state == "UT"
+        assert actual.zip == 84058
+
+        desrl = k._deserializer(Serials.json)
+        actual = helping.datify(Record, desrl(json))
+        assert actual.first == "Jim"
+        assert actual.last == "Black"
+        assert actual.street == "100 Main Street"
+        assert actual.city == "Riverton"
+        assert actual.state == "UT"
+        assert actual.zip == 84058
+
+        desrl = k._deserializer(Serials.cbor)
+        actual = helping.datify(Record, desrl(cbor))
+        assert actual.first == "Jim"
+        assert actual.last == "Black"
+        assert actual.street == "100 Main Street"
+        assert actual.city == "Riverton"
+        assert actual.state == "UT"
+        assert actual.zip == 84058


### PR DESCRIPTION
Addresses #147 

Basic `get`/`put`/`rem` via a KOM based off a `@dataclass`

In addition to the KOM implementation I added coverage options.

These can be run:

`coverage run -m pytest`
`open htmlcov/index.html`