### PR TITLE
adds compact json and ensure_ascii=False, storing Unicode characters …

### DIFF
--- a/src/keri/base/basing.py
+++ b/src/keri/base/basing.py
@@ -127,7 +127,7 @@ class Komer:
     def __serializeJSON(val):
         if val is None:
             return
-        return json.dumps(asdict(val)).encode("utf-8")
+        return json.dumps(asdict(val), separators=(",", ":"), ensure_ascii=False).encode("utf-8")
 
     @staticmethod
     def __serializeMGPK(val):

--- a/tests/base/test_basing.py
+++ b/tests/base/test_basing.py
@@ -170,7 +170,7 @@ def test_serialization():
         assert srl(jim) == expected
 
         srl = k._serializer(Serials.json)
-        expected = b'{"first": "Jim", "last": "Black", "street": "100 Main Street", "city": "Riverton", "state": "UT", "zip": 84058}'
+        expected = b'{"first":"Jim","last":"Black","street":"100 Main Street","city":"Riverton","state":"UT","zip":84058}'
         assert srl(jim) == expected
 
 


### PR DESCRIPTION
…as-is instead of \u escape sequence

Signed-off-by: Kevin Griffin <griffin.kev@gmail.com>